### PR TITLE
chore: fix dependencies outside of hatch envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.0.1] - unreleased
+## [0.0.2] - 2023-01-26
+
+- Properly depend on our dependencies instead of only in the hatch environment.
+
+## [0.0.1] - 2023-01-25
 
 ### Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,15 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["twisted"]
-version = "0.0.1"
+dependencies = [
+  "twisted",
+  "cachetools",
+  "asyncache",
+  "jwcrypto",
+  "pyopenssl",
+  "matrix-synapse"
+]
+version = "0.0.2"
 
 [project.urls]
 Documentation = "https://github.com/famedly/synapse-invite-checker#synapse-invite-checker"
@@ -33,12 +40,7 @@ dependencies = [
   "black",
   "pytest",
   "pytest-cov",
-  "mock",
-  "matrix-synapse",
-  "cachetools",
-  "asyncache",
-  "jwcrypto",
-  "pyopenssl"
+  "mock"
 ]
 [tool.hatch.envs.default.scripts]
 cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=synapse_invite_checker --cov=tests"

--- a/synapse_invite_checker/invite_checker.py
+++ b/synapse_invite_checker/invite_checker.py
@@ -140,7 +140,7 @@ class FederationAllowListClient(BaseHttpClient):
 
 
 class InviteChecker:
-    __version__ = "0.0.1"
+    __version__ = "0.0.2"
 
     def __init__(self, config: InviteCheckerConfig, api: ModuleApi):
         self.api = api


### PR DESCRIPTION
Otherwise pip install won't pull them in