### PR TITLE
fix: don't directly depend on synapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.3] - 2023-01-26
+
+- Drop direct dependency on synapse to prevent pip from overwriting the locally installed one
+
 ## [0.0.2] - 2023-01-26
 
 - Properly depend on our dependencies instead of only in the hatch environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,9 @@ dependencies = [
   "cachetools",
   "asyncache",
   "jwcrypto",
-  "pyopenssl",
-  "matrix-synapse"
+  "pyopenssl"
 ]
-version = "0.0.2"
+version = "0.0.3"
 
 [project.urls]
 Documentation = "https://github.com/famedly/synapse-invite-checker#synapse-invite-checker"
@@ -40,7 +39,8 @@ dependencies = [
   "black",
   "pytest",
   "pytest-cov",
-  "mock"
+  "mock",
+  "matrix-synapse" # we don't depend on synapse directly to prevent pip from pulling the wrong synapse, when we just want to install the module
 ]
 [tool.hatch.envs.default.scripts]
 cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=synapse_invite_checker --cov=tests"

--- a/synapse_invite_checker/invite_checker.py
+++ b/synapse_invite_checker/invite_checker.py
@@ -140,7 +140,7 @@ class FederationAllowListClient(BaseHttpClient):
 
 
 class InviteChecker:
-    __version__ = "0.0.2"
+    __version__ = "0.0.3"
 
     def __init__(self, config: InviteCheckerConfig, api: ModuleApi):
         self.api = api


### PR DESCRIPTION
Otherwise pip manually installs a possibly conflicting Synapse. Since this is a module we can assume there is always a Synapse present already, when it gets loaded.