### PR TITLE
fix: CN to SUB-CA needs to replaces spaces with underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.4] - 2023-01-29
+
+- Properly map CN to SUB-CA certificates
+
 ## [0.0.3] - 2023-01-26
 
 - Drop direct dependency on synapse to prevent pip from overwriting the locally installed one

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "jwcrypto",
   "pyopenssl"
 ]
-version = "0.0.3"
+version = "0.0.4"
 
 [project.urls]
 Documentation = "https://github.com/famedly/synapse-invite-checker#synapse-invite-checker"

--- a/synapse_invite_checker/invite_checker.py
+++ b/synapse_invite_checker/invite_checker.py
@@ -140,7 +140,7 @@ class FederationAllowListClient(BaseHttpClient):
 
 
 class InviteChecker:
-    __version__ = "0.0.3"
+    __version__ = "0.0.4"
 
     def __init__(self, config: InviteCheckerConfig, api: ModuleApi):
         self.api = api
@@ -264,7 +264,7 @@ class InviteChecker:
 
     async def _raw_gematik_intermediate_cert_fetch(self, cn: str) -> bytes:
         return await self.api.http_client.get_raw(
-            f"{self.config.gematik_ca_baseurl}/ECC/SUB-CA/{quote(cn, safe='')}.der"
+            f"{self.config.gematik_ca_baseurl}/ECC/SUB-CA/{quote(cn.replace(' ', '_'), safe='')}.der"
         )
 
     def _load_cert_b64(self, cert: str) -> X509:


### PR DESCRIPTION
Fixes the error encountered in prod and bumps the version at the same time.