### PR TITLE
fix: all contact API statements failing because "user" is a keyword o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.9] - 2023-02-10
+
+BREAKING: rename user column to avoid issues with SQL statements on postgres (that aren't handled by the synapse DB
+API). This also renames the table to simplify migration. You may want to delete the old (and probably empty table).
+
 ## [0.0.8] - 2023-02-09
 
 - Deal with quoted strings returned as the localization

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "jwcrypto",
   "pyopenssl"
 ]
-version = "0.0.8"
+version = "0.0.9"
 
 [project.urls]
 Documentation = "https://github.com/famedly/synapse-invite-checker#synapse-invite-checker"

--- a/synapse_invite_checker/invite_checker.py
+++ b/synapse_invite_checker/invite_checker.py
@@ -140,7 +140,7 @@ class FederationAllowListClient(BaseHttpClient):
 
 
 class InviteChecker:
-    __version__ = "0.0.8"
+    __version__ = "0.0.9"
 
     def __init__(self, config: InviteCheckerConfig, api: ModuleApi):
         self.api = api


### PR DESCRIPTION
…n PG

The synapse db API seems to not quote table names. We could work around that by quoting them ourselves when passing them as values, but that might break in the future. Instead we just rename the column to something less error prone.

Currently no migration is provided, since it is easier to rename the table for now and let it be recreated. You may want to delete the old table eventually.