### PR TITLE
chore: Add matrix team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @famedly/workflows
+* @famedly/workflows @famedly/matrix-team


### PR DESCRIPTION
The matrix team is probably now the primary party responsible for synapse and its modules. As such add us to the CODEOWNERS, so that we can review stuff. Not removing workflows for now, since the matrix team is quite small and it is very helpful, if sometimes externals can do reviews, when some of us are unavailable.