### PR TITLE
chore: Update versions returned by various schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Here are the available configuration options:
 modules:
   - module: "synapse_invite_checker.InviteChecker"
     config:
-        api_prefix: "/_synapse/client/test", # Prefix to expose these endpoints under, optional, configure only if you know why you need to change it.
         title: "TIM Contact API by Famedly", # Title for the info endpoint, optional
         description: "Custom description for the endpoint", # Description for the info endpoint, optional
         contact: "random@example.com", # Contact information for the info endpoint, optional

--- a/synapse_invite_checker/rest/base.py
+++ b/synapse_invite_checker/rest/base.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020,2023 Famedly
+# Copyright (C) 2020,2024 Famedly
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -12,15 +12,16 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-from dataclasses import dataclass
+import re
 
 
-@dataclass
-class InviteCheckerConfig:
-    title: str = "Invite Checker module by Famedly"
-    description: str = "Invite Checker module by Famedly"
-    contact: str = "info@famedly.com"
-    federation_list_url: str = ""
-    federation_list_client_cert: str = ""
-    federation_localization_url: str = ""
-    gematik_ca_baseurl: str = ""
+def invite_checker_pattern(root_prefix: str, path_regex: str):
+    path = path_regex.removeprefix("/")
+    root = root_prefix.removesuffix("/")
+    raw_regex = f"^{root}/{path}"
+
+    # we need to strip the /$, otherwise we can't register for the root of the prefix in a handler...
+    if raw_regex.endswith("/$"):
+        raw_regex = raw_regex.replace("/$", "$")
+
+    return [re.compile(raw_regex)]

--- a/synapse_invite_checker/rest/messenger_info.py
+++ b/synapse_invite_checker/rest/messenger_info.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2020,2024 Famedly
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+import re
+from http import HTTPStatus
+from typing import List
+
+from synapse.http.servlet import RestServlet
+from synapse.http.site import SynapseRequest
+from synapse.types import JsonDict
+
+from synapse_invite_checker.config import InviteCheckerConfig
+from synapse_invite_checker.rest.base import invite_checker_pattern
+
+# Version of TiMessengerInformation interface. See:
+# https://github.com/gematik/api-ti-messenger/blob/main/src/openapi/TiMessengerInformation.yaml
+_TMI_schema_version = "1.0.0"
+
+INFO_API_PREFIX = "/_synapse/client/com.famedly/tim/tim-information"
+
+
+def tim_info_patterns(path_regex: str) -> List[re.Pattern]:
+    return invite_checker_pattern(INFO_API_PREFIX, path_regex)
+
+
+class MessengerInfoResource(RestServlet):
+    def __init__(self, config: InviteCheckerConfig):
+        super().__init__()
+        self.config = config
+        self.version = _TMI_schema_version
+
+        self.PATTERNS = tim_info_patterns("/$")
+
+    # @override
+    async def on_GET(self, _: SynapseRequest) -> tuple[int, JsonDict]:
+        return HTTPStatus.OK, {
+            "title": self.config.title,
+            "description": self.config.description,
+            "contact": self.config.contact,
+            "version": self.version,
+        }

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -252,55 +252,6 @@ class ModuleApiTestCase(synapsetest.HomeserverTestCase):
         return conf
 
 
-class InfoResourceTest(ModuleApiTestCase):
-    async def test_registered_default_info_resource(self) -> None:
-        """Tests that the registered info resource is accessible"""
-
-        channel = self.make_request(
-            method="GET",
-            path="/_synapse/client/com.famedly/tim/v1",
-        )
-
-        assert channel.code == 200, channel.result
-        assert channel.json_body["title"] == "Invite Checker module by Famedly"
-        assert channel.json_body["description"] == "Invite Checker module by Famedly"
-        assert channel.json_body["contact"] == "info@famedly.com"
-        assert channel.json_body["version"], "Version returned"
-
-    @synapsetest.override_config(
-        {
-            "modules": [
-                {
-                    "module": "synapse_invite_checker.InviteChecker",
-                    "config": {
-                        "api_prefix": "/_synapse/client/test",
-                        "title": "abc",
-                        "description": "def",
-                        "contact": "ghi",
-                        "federation_list_url": "https://localhost:8080",
-                        "federation_localization_url": "https://localhost:8000/localization",
-                        "federation_list_client_cert": "tests/certs/client.pem",
-                        "gematik_ca_baseurl": "https://download-ref.tsl.ti-dienste.de/",
-                    },
-                }
-            ]
-        }
-    )
-    def test_registered_custom_info_resource(self) -> None:
-        """Tests that the registered info resource is accessible and has the configured values"""
-
-        channel = self.make_request(
-            method="GET",
-            path="/_synapse/client/test",
-        )
-
-        assert channel.code == 200, channel.result
-        assert channel.json_body["title"] == "abc"
-        assert channel.json_body["description"] == "def"
-        assert channel.json_body["contact"] == "ghi"
-        assert channel.json_body["version"], "Version returned"
-
-
 class LocalInviteTest(ModuleApiTestCase):
     def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
         super().prepare(reactor, clock, homeserver)
@@ -578,6 +529,20 @@ class ContactsApiTest(ModuleApiTestCase):
 
         # authenticated as user_a
         self.helper.auth_user_id = self.user_a
+
+    async def test_contact_management_info_resource(self) -> None:
+        """Tests that the registered info resource is accessible"""
+
+        channel = self.make_request(
+            method="GET",
+            path="/_synapse/client/com.famedly/tim/v1",
+        )
+
+        assert channel.code == 200, channel.result
+        assert channel.json_body["title"] == "Invite Checker module by Famedly"
+        assert channel.json_body["description"] == "Invite Checker module by Famedly"
+        assert channel.json_body["contact"] == "info@famedly.com"
+        assert channel.json_body["version"], "Version returned"
 
     def test_list_contacts(self) -> None:
         # Requires authentication
@@ -957,3 +922,51 @@ class FederationDomainSchemaTest(ModuleApiTestCase):
         assert test_entry.telematikID == "1-SMC-B-Testkarte-883110000096089"
         assert test_entry.timAnbieter is None
         assert test_entry.isInsurance is False
+
+
+class MessengerInfoTestCase(ModuleApiTestCase):
+    async def test_default_operator_contact_info_resource(self) -> None:
+        """Tests that the messenger operator contact info resource is accessible"""
+
+        channel = self.make_request(
+            method="GET",
+            path="/_synapse/client/com.famedly/tim/tim-information",
+        )
+
+        assert channel.code == 200, channel.result
+        assert channel.json_body["title"] == "Invite Checker module by Famedly"
+        assert channel.json_body["description"] == "Invite Checker module by Famedly"
+        assert channel.json_body["contact"] == "info@famedly.com"
+        assert channel.json_body["version"], "Version returned"
+
+    @synapsetest.override_config(
+        {
+            "modules": [
+                {
+                    "module": "synapse_invite_checker.InviteChecker",
+                    "config": {
+                        "title": "abc",
+                        "description": "def",
+                        "contact": "ghi",
+                        "federation_list_url": "https://localhost:8080",
+                        "federation_localization_url": "https://localhost:8000/localization",
+                        "federation_list_client_cert": "tests/certs/client.pem",
+                        "gematik_ca_baseurl": "https://download-ref.tsl.ti-dienste.de/",
+                    },
+                }
+            ]
+        }
+    )
+    def test_custom_operator_contact_info_resource(self) -> None:
+        """Tests that the registered info resource is accessible and has the configured values"""
+
+        channel = self.make_request(
+            method="GET",
+            path="/_synapse/client/com.famedly/tim/tim-information",
+        )
+
+        assert channel.code == 200, channel.result
+        assert channel.json_body["title"] == "abc"
+        assert channel.json_body["description"] == "def"
+        assert channel.json_body["contact"] == "ghi"
+        assert channel.json_body["version"], "Version returned"


### PR DESCRIPTION
Fixes:
* #27

Specifically, this updates the schema version for the contact management api and the operator contact information.

Added a new api endpoint at `/_synapse/client/com.famedly/tim/tim-information` for providing the contact information of the operator that deployed this module.

Removed the `api_prefix` setting. It appears to be completely unused anywhere and could have led to a configuration error if utilized incorrectly

Future work for 'Pro' mode can utilize this root for other information