### PR TITLE
ci: properly write coverage files in CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,10 +2,10 @@ name: Python
 
 on:
   push:
-    branches: [ "main" ]
-    tags: [ "*" ]
+    branches: ["main"]
+    tags: ["*"]
   pull_request:
-    branches: [ "*" ]
+    branches: ["*"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,7 +22,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10", "3.11" ]
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
 
@@ -41,7 +41,7 @@ jobs:
         uses: famedly/black@stable
         with:
           options: "--check --verbose"
-      
+
       - name: Prepare lint
         shell: bash
         run: echo PYTHON_TARGET="py${{ matrix.python-version }}" | sed -r "s/\.//" >> $GITHUB_ENV
@@ -53,6 +53,9 @@ jobs:
 
       - name: Tests and coverage
         run: hatch run cov
+        env:
+          # to ensure we run ci:cov instead of default:cov, where the former generates more coverage files
+          HATCH_ENV: "ci"
 
       - name: Codecov - Upload coverage
         uses: codecov/codecov-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ _trial_temp
 venv
 dist
 .coverage
+coverage.xml
 base.lcov
 head.lcov
 lcov.info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=synaps
 format = "black ."
 # For CI use
 [tool.hatch.envs.ci.scripts]
-cov = "pytest --cov-report=lcov:lcov.info --cov-config=pyproject.toml --cov=synapse_invite_checker --cov=tests"
+cov = "pytest --cov-report=lcov:lcov.info --cov-report=xml --cov-report=term-missing --cov-config=pyproject.toml --cov=synapse_invite_checker --cov=tests"
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
By default we were only running the coverage command from the default environment, which doesn't write coverage files. The "cov" script in the "ci" environment does.

Also extend that script to write coverage.xml and to the terminal in addition to the lcov file, even though currently we only upload the lcov.info.