### PR TITLE
Contact REST Api migration

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -37,6 +37,17 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install hatch
 
+      - name: Set up PostgreSQL 15
+        # 1. Mount postgres data files onto a tmpfs in-memory filesystem to reduce overhead of docker's overlayfs layer.
+        # 2. Expose the unix socket for postgres. This removes latency of using docker-proxy for connections.
+        run: |
+          docker run -d -p 5432:5432 \
+            --tmpfs /var/lib/postgres:rw,size=6144m \
+            --mount 'type=bind,src=/var/run/postgresql,dst=/var/run/postgresql' \
+            -e POSTGRES_PASSWORD=postgres \
+            -e POSTGRES_INITDB_ARGS="--lc-collate C --lc-ctype C --encoding UTF8" \
+            postgres:15
+
       - name: Formatting
         uses: famedly/black@stable
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
   "pytest-cov",
   "mock",
   "parameterized",
+  "psycopg2",
   "matrix-synapse" # we don't depend on synapse directly to prevent pip from pulling the wrong synapse, when we just want to install the module
 ]
 [tool.hatch.envs.default.scripts]
@@ -52,6 +53,16 @@ format = "black ."
 # For CI use
 [tool.hatch.envs.ci.scripts]
 cov = "pytest --cov-report=lcov:lcov.info --cov-report=xml --cov-report=term-missing --cov-config=pyproject.toml --cov=synapse_invite_checker --cov=tests"
+
+[[tool.hatch.envs.ci.matrix]]
+database = [ "postgres", "sqlite"]
+
+[tool.hatch.envs.ci.overrides]
+matrix.database.env-vars = [
+  { key = "SYNAPSE_POSTGRES", value = "1", if = ["postgres"] },
+  { key = "SYNAPSE_POSTGRES_USER", value = "postgres", if = ["postgres"] },
+  { key = "SYNAPSE_POSTGRES_PASSWORD", value = "postgres", if = ["postgres"] },
+]
 
 [tool.coverage.run]
 branch = true

--- a/synapse_invite_checker/permissions.py
+++ b/synapse_invite_checker/permissions.py
@@ -1,0 +1,96 @@
+# Copyright (C) 2025 Famedly
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+from typing import Awaitable, Callable
+
+from synapse.module_api import ModuleApi
+from synapse.types import UserID
+
+from synapse_invite_checker.types import (
+    PermissionConfig,
+    PermissionConfigType,
+    PermissionDefaultSetting,
+)
+
+
+class InviteCheckerPermissionsHandler:
+    """
+    Used to retrieve and store permissions for users while taking into account the event type
+    of configuration as required by gematik spec.
+
+    A great deal of this can be removed after the Contacts REST Api has been removed
+    """
+
+    def __init__(
+        self,
+        api: ModuleApi,
+        localization_cb: Callable[[str], Awaitable[str]],
+        is_domain_insurance_cb: Callable[[str], Awaitable[bool]],
+    ) -> None:
+        self.api = api
+        self.account_data_manager = self.api.account_data_manager
+        self.fetch_localization_for_mxid = localization_cb
+        self.is_domain_insurance = is_domain_insurance_cb
+
+    async def get_permissions(self, user_id: str) -> PermissionConfig:
+        config_type = await self.get_config_type_from_mxid(user_id)
+        account_data = await self.account_data_manager.get_global(
+            user_id, config_type.value
+        )
+        if account_data is None:
+            permissions = PermissionConfig(
+                defaultSetting=PermissionDefaultSetting.BLOCK_ALL,
+            )
+        else:
+            permissions = PermissionConfig.model_validate(account_data)
+        return permissions
+
+    async def update_permissions(
+        self,
+        user_id: str,
+        permissions: PermissionConfig,
+    ) -> None:
+        # Will be removed after Contacts API has been deprecated
+        config_type = await self.get_config_type_from_mxid(user_id)
+        await self.account_data_manager.put_global(
+            user_id,
+            config_type.value,
+            permissions.dump(),
+        )
+
+    async def get_config_type_from_mxid(
+        self, local_user_id: str
+    ) -> PermissionConfigType:
+        """
+        Identify(as best can be done) what type of local User it is
+        """
+        local_mxid_domain = UserID.from_string(local_user_id).domain
+        # Recall that the request used here is cached from the federation list
+        if await self.is_domain_insurance(local_mxid_domain):
+            config_type = PermissionConfigType.EPA_ACCOUNT_DATA_TYPE
+        else:
+            config_type = PermissionConfigType.PRO_ACCOUNT_DATA_TYPE
+        return config_type
+
+    async def is_user_allowed(self, local_user_id: str, remote_mxid: str) -> bool:
+        """
+        The primary check used by InviteChecker's user_may_invite()
+        """
+        permissions = await self.get_permissions(local_user_id)
+        is_remote_mxid_insurance = await self.is_domain_insurance(
+            UserID.from_string(remote_mxid).domain
+        )
+        return permissions.is_mxid_allowed_to_contact(
+            remote_mxid, is_mxid_epa=is_remote_mxid_insurance
+        )

--- a/synapse_invite_checker/store.py
+++ b/synapse_invite_checker/store.py
@@ -21,7 +21,7 @@ from synapse.storage.database import (
     LoggingDatabaseConnection,
     LoggingTransaction,
 )
-from synapse.types import UserID
+from synapse.storage.engines import PostgresEngine
 
 from synapse_invite_checker.types import Contact, Contacts, InviteSettings
 
@@ -38,46 +38,80 @@ class InviteCheckerStore(SQLBaseStore):
         super().__init__(database, db_conn, hs)
 
         self.db_checked = False
+        self.db_exists = False
 
-    async def ensure_table_exists(self):
-        if not self.db_checked:
+    async def table_exists(self, force: bool = False) -> bool:
+        if not self.db_checked or force:
+            # TODO: need to test this, use a hatch matrix
+            if isinstance(self.db_pool.engine, PostgresEngine):
+                schema_table = "information_schema.tables"
+                where_clause = "table_name='famedly_invite_checker_contacts'"
+            else:
+                schema_table = "sqlite_master"
+                where_clause = "type='table' AND name='famedly_invite_checker_contacts'"
 
-            def ensure_table_exists_txn(txn: LoggingTransaction) -> bool:
-                sql = """
-                    CREATE TABLE IF NOT EXISTS famedly_invite_checker_contacts (
-                        "owning_user" TEXT NOT NULL,
-                        "contact_display_name" TEXT NOT NULL,
-                        "contact_mxid" TEXT NOT NULL,
-                        "contact_invite_settings_start" BIGINT NOT NULL,
-                        "contact_invite_settings_end" BIGINT
-                    );
-                    """
-                txn.execute(sql)
-                txn.execute(
-                    """
-                            CREATE INDEX IF NOT EXISTS famedly_invite_checker_contacts_user
-                            ON famedly_invite_checker_contacts("owning_user");
-                            """
-                )
-                txn.execute(
-                    """
-                            CREATE UNIQUE INDEX IF NOT EXISTS famedly_invite_checker_contacts_user_mxid
-                            ON famedly_invite_checker_contacts("owning_user", "contact_mxid");
-                            """
-                )
-                return True
+            sql = f"SELECT EXISTS (SELECT 1 FROM {schema_table} WHERE {where_clause})"
 
-            await self.db_pool.runInteraction(
-                "ensure_invite_checker_table_exists", ensure_table_exists_txn
+            result = await self.db_pool.execute(
+                "check_invite_checker_table_exists", sql
             )
 
             self.db_checked = True
+            self.db_exists = bool(result[0][0])
 
-    async def get_contacts(self, user: UserID) -> Contacts:
-        await self.ensure_table_exists()
+        return self.db_exists
+
+    async def ensure_table_exists(self):
+        def ensure_table_exists_txn(txn: LoggingTransaction) -> bool:
+            sql = """
+                CREATE TABLE IF NOT EXISTS famedly_invite_checker_contacts (
+                    "owning_user" TEXT NOT NULL,
+                    "contact_display_name" TEXT NOT NULL,
+                    "contact_mxid" TEXT NOT NULL,
+                    "contact_invite_settings_start" BIGINT NOT NULL,
+                    "contact_invite_settings_end" BIGINT
+                );
+                """
+            txn.execute(sql)
+            txn.execute(
+                """
+                        CREATE INDEX IF NOT EXISTS famedly_invite_checker_contacts_user
+                        ON famedly_invite_checker_contacts("owning_user");
+                        """
+            )
+            txn.execute(
+                """
+                        CREATE UNIQUE INDEX IF NOT EXISTS famedly_invite_checker_contacts_user_mxid
+                        ON famedly_invite_checker_contacts("owning_user", "contact_mxid");
+                        """
+            )
+            return True
+
+        await self.db_pool.runInteraction(
+            "ensure_invite_checker_table_exists", ensure_table_exists_txn
+        )
+        # Just created the table, unilaterally tell the store to recheck it's there
+        self.db_checked = False
+
+    async def drop_table(self) -> None:
+        if await self.table_exists(force=True):
+
+            def drop(conn: LoggingDatabaseConnection) -> None:
+                cur = conn.cursor(txn_name="check_invite_checker_drop_table")
+                self.db_pool.engine.executescript(
+                    cur, "DROP TABLE IF EXISTS famedly_invite_checker_contacts;"
+                )
+
+            await self.db_pool.runWithConnection(drop)
+
+            self.db_checked = False
+
+    async def get_contacts(self, user: str) -> Contacts | None:
+        if not await self.table_exists():
+            return
         contacts = await self.db_pool.simple_select_list(
             "famedly_invite_checker_contacts",
-            keyvalues={"owning_user": user.to_string()},
+            keyvalues={"owning_user": user},
             retcols=(
                 "contact_display_name",
                 "contact_mxid",
@@ -86,32 +120,46 @@ class InviteCheckerStore(SQLBaseStore):
             ),
             desc="famedly_invite_checker_get_contacts",
         )
-        return Contacts(
-            contacts=[
-                Contact(
-                    displayName=name,
-                    mxid=mxid,
-                    inviteSettings=InviteSettings(start=start, end=end),
-                )
-                for (name, mxid, start, end) in contacts
-            ]
+        return (
+            Contacts(
+                contacts=[
+                    Contact(
+                        displayName=name,
+                        mxid=mxid,
+                        inviteSettings=InviteSettings(start=start, end=end),
+                    )
+                    for (name, mxid, start, end) in contacts
+                ]
+            )
+            if contacts
+            else None
         )
 
-    async def del_contact(self, user: UserID, contact: str) -> None:
-        await self.ensure_table_exists()
+    async def del_contact(self, user: str, contact: str) -> None:
+        if not await self.table_exists():
+            return
         await self.db_pool.simple_delete(
             "famedly_invite_checker_contacts",
-            {"owning_user": user.to_string(), "contact_mxid": contact},
+            {"owning_user": user, "contact_mxid": contact},
             desc="famedly_invite_checker_del_contact",
         )
 
-    async def add_contact(self, user: UserID, contact: Contact) -> None:
-        await self.ensure_table_exists()
+    async def del_contacts(self, user: str) -> None:
+        if await self.table_exists():
+            await self.db_pool.simple_delete(
+                "famedly_invite_checker_contacts",
+                {"owning_user": user},
+                desc="famedly_invite_checker_del_contacts",
+            )
+
+    async def add_contact(self, user: str, contact: Contact) -> None:
+        if not await self.table_exists():
+            return
         await self.db_pool.simple_upsert(
             "famedly_invite_checker_contacts",
-            keyvalues={"owning_user": user.to_string(), "contact_mxid": contact.mxid},
+            keyvalues={"owning_user": user, "contact_mxid": contact.mxid},
             values={
-                "owning_user": user.to_string(),
+                "owning_user": user,
                 "contact_mxid": contact.mxid,
                 "contact_display_name": contact.displayName,
                 "contact_invite_settings_start": contact.inviteSettings.start,
@@ -120,11 +168,12 @@ class InviteCheckerStore(SQLBaseStore):
             desc="famedly_invite_checker_add_contact",
         )
 
-    async def get_contact(self, user: UserID, contact_mxid: str) -> Contact | None:
-        await self.ensure_table_exists()
+    async def get_contact(self, user: str, contact_mxid: str) -> Contact | None:
+        if not await self.table_exists():
+            return None
         contact = await self.db_pool.simple_select_one(
             "famedly_invite_checker_contacts",
-            keyvalues={"owning_user": user.to_string(), "contact_mxid": contact_mxid},
+            keyvalues={"owning_user": user, "contact_mxid": contact_mxid},
             retcols=(
                 "contact_display_name",
                 "contact_mxid",
@@ -142,3 +191,23 @@ class InviteCheckerStore(SQLBaseStore):
                 inviteSettings=InviteSettings(start=start, end=end),
             )
         return None
+
+    async def get_all_contact_owners_for_migration(self) -> set[str]:
+        """
+        Retrieves all contact owner rows from the database to begin migration. May be run
+        more than once and will just return an empty Set instead of None
+        """
+        contact_owners: set[str] = set()
+        if await self.table_exists():
+            # I'm not sure I like how this pulls data duplicatedly
+            contact_rows = await self.db_pool.simple_select_list(
+                "famedly_invite_checker_contacts",
+                keyvalues=None,
+                retcols=("owning_user",),
+                desc="famedly_invite_checker_store_migration",
+            )
+            for (owning_user,) in contact_rows:
+                logger.debug(f"FOUND OWNING USER: {owning_user}")
+                contact_owners.add(owning_user)
+
+        return contact_owners

--- a/synapse_invite_checker/types.py
+++ b/synapse_invite_checker/types.py
@@ -14,8 +14,10 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 from enum import Enum, auto
 from functools import cached_property
+from typing import Annotated, Any
 
-from pydantic import BaseModel, ConfigDict, computed_field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
+from synapse.types import UserID
 
 
 class InviteSettings(BaseModel):
@@ -43,6 +45,102 @@ class Contacts(BaseModel):
     )
 
     contacts: list[Contact]
+
+
+class PermissionDefaultSetting(Enum):
+    ALLOW_ALL = "allow all"
+    BLOCK_ALL = "block all"
+
+
+class GroupName(Enum):
+    isInsuredPerson = "isInsuredPerson"
+
+
+class PermissionConfig(BaseModel):
+    model_config = ConfigDict(
+        extra="ignore",
+        allow_inf_nan=False,
+        use_enum_values=True,
+    )
+
+    # I believe that it should be correct to set the default value here, but the method
+    # used to extract the data later(see dump() below, specifically 'exclude_defaults=True')
+    # will then not include it. Imported data does not have this issue. See
+    # InviteCheckerPermissionsHandler.get_permissions() for where it is set now.
+    # TLDR: this will not be an important detail after migrations have run as it will
+    # always be set during class instantiation
+    defaultSetting: PermissionDefaultSetting = None
+    # If any of these three exists, they should contain a dict with the key as the
+    # exception and then an empty dict inside "for future expansion"
+    serverExceptions: Annotated[dict[str, dict], Field(default_factory=dict)] = None
+    # If there is a key inside userExceptions, it needs to be sure to start with a '@'.
+    # Should we validate this or trust the client app does the right thing?
+    userExceptions: Annotated[dict[str, dict], Field(default_factory=dict)] = None
+    groupExceptions: Annotated[list[dict[str, str]], Field(default_factory=list)] = None
+
+    def maybe_get_contact(self, mxid: str) -> Contact | None:
+        """
+        Used by the Contact REST Api to look like a Contact.
+        """
+        # Will be removed after Contacts API has been deprecated
+        if mxid in self.userExceptions:
+            return Contact(
+                displayName="",
+                mxid=mxid,
+                inviteSettings=InviteSettings(start=0, end=None),
+            )
+        return None
+
+    def get_contacts(self) -> Contacts:
+        """
+        Used by the Contacts REST Api to look like a Contacts
+        """
+        return Contacts(
+            contacts=[
+                Contact(
+                    # Not certain what to use for displayName, that data isn't
+                    # available anymore. I think the client has to sort it out
+                    displayName="",
+                    mxid=mxid,
+                    inviteSettings=InviteSettings(start=0, end=None),
+                )
+                for mxid in self.userExceptions
+            ]
+        )
+
+    def dump(self) -> dict[str, Any]:
+        # exclude_none=True strips out the attributes that are None so they do translate
+        # to JSON as 'null'. exclude_defaults=True strips out attributes in the same
+        # way. It does not touch empty dict sub-attributes only top level!!
+        # mode="json" turns the classes into their string names.
+        return self.model_dump(mode="json", exclude_none=True, exclude_defaults=True)
+
+    def is_allow_all(self):
+        return self.defaultSetting == PermissionDefaultSetting.ALLOW_ALL.value
+
+    def is_mxid_allowed_to_contact(self, mxid: str, is_mxid_epa: bool) -> bool:
+        """
+        The main test for allowing or blocking an invitation.
+        """
+        mxid_domain = UserID.from_string(mxid).domain
+        allowed = self.is_allow_all()
+
+        if is_mxid_epa and self.is_group_excepted(GroupName.isInsuredPerson):
+            allowed = not allowed
+
+        elif mxid_domain in self.serverExceptions:
+            allowed = not allowed
+        elif mxid in self.userExceptions:
+            allowed = not allowed
+
+        return allowed
+
+    def is_group_excepted(self, group_name: GroupName) -> bool:
+        return any(
+            True
+            for groupException in self.groupExceptions
+            if groupException.get("groupName") == group_name.value
+        )
 
 
 class FederationDomain(BaseModel):
@@ -99,3 +197,8 @@ class FederationList(BaseModel):
 class TimType(Enum):
     PRO = auto()
     EPA = auto()
+
+
+class PermissionConfigType(Enum):
+    EPA_ACCOUNT_DATA_TYPE = "de.gematik.tim.account.permissionconfig.epa.v1"
+    PRO_ACCOUNT_DATA_TYPE = "de.gematik.tim.account.permissionconfig.pro.v1"

--- a/tests/base.py
+++ b/tests/base.py
@@ -238,6 +238,8 @@ class FakeInviteResponse:
 
 
 class ModuleApiTestCase(synapsetest.HomeserverTestCase):
+    server_name_for_this_server = SERVER_NAME_FROM_LIST
+
     @classmethod
     def setUpClass(cls):
         cls._patcher1 = patch(
@@ -302,7 +304,7 @@ class ModuleApiTestCase(synapsetest.HomeserverTestCase):
         return self.setup_test_homeserver(
             # Masquerade as a domain found on the federation list, then we can pass
             # tests that verify that fact
-            SERVER_NAME_FROM_LIST,
+            self.server_name_for_this_server,
             federation_transport_client=self.fed_transport_client,
             federation_handler=self.fed_handler,
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -94,7 +94,7 @@ class ConfigParsingTestCase(TestCase):
                 "federation_localization_url": "http://localhost:8080/localization",
             }
         )
-        # self.assertRaises(Exception, InviteChecker.parse_config, test_config)
+
         assert InviteChecker.parse_config(test_config), "Exception maybe?"
 
     def test_mismatch_scheme_between_fedlist_and_fedloc_raises(self) -> None:

--- a/tests/test_createrooms_local.py
+++ b/tests/test_createrooms_local.py
@@ -24,6 +24,7 @@ from tests.base import (
     ModuleApiTestCase,
     construct_extra_content,
 )
+from tests.test_utils import INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL
 
 
 class LocalProModeCreateRoomTest(ModuleApiTestCase):
@@ -176,6 +177,8 @@ class LocalEpaModeCreateRoomTest(ModuleApiTestCase):
     ePA mode configurations should never have 'pract', 'org' or 'orgPract' Users, so
     they are not included in these tests
     """
+
+    server_name_for_this_server = INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
         super().prepare(reactor, clock, homeserver)

--- a/tests/test_createrooms_remote.py
+++ b/tests/test_createrooms_remote.py
@@ -21,7 +21,12 @@ from synapse.util import Clock
 from twisted.internet.testing import MemoryReactor
 
 from tests.base import ModuleApiTestCase, construct_extra_content
-from tests.test_utils import DOMAIN_IN_LIST, INSURANCE_DOMAIN_IN_LIST
+from tests.test_utils import (
+    DOMAIN_IN_LIST,
+    INSURANCE_DOMAIN_IN_LIST,
+    INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL,
+)
+
 
 """
 These tests all focus on room creation at the API level. This allows us to test:
@@ -289,6 +294,7 @@ class RemoteEpaModeCreateRoomTest(ModuleApiTestCase):
     remote_pro_user = f"@mxid:{DOMAIN_IN_LIST}"
     remote_epa_user = f"@alice:{INSURANCE_DOMAIN_IN_LIST}"
     remote_non_fed_list_user = "@rando:fake-website.com"
+    server_name_for_this_server = INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
         super().prepare(reactor, clock, homeserver)
@@ -298,7 +304,7 @@ class RemoteEpaModeCreateRoomTest(ModuleApiTestCase):
         #  @c:test is an 'orgPract'
         # as they should not exist on an 'ePA' mode server backend
 
-        # @d:test is non of these things and should be just a 'User'
+        # @d:test is none of these things and should be just a 'User'
         self.user_d = self.register_user("d", "password")
         self.user_e = self.register_user("e", "password")
         self.access_token_d = self.login("d", "password")

--- a/tests/test_local_invites.py
+++ b/tests/test_local_invites.py
@@ -19,6 +19,7 @@ from synapse.util import Clock
 from twisted.internet.testing import MemoryReactor
 
 from tests.base import ModuleApiTestCase
+from tests.test_utils import INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL
 
 
 class LocalProModeInviteTest(ModuleApiTestCase):
@@ -167,6 +168,8 @@ class LocalEpaModeInviteTest(ModuleApiTestCase):
     which will require assuming the identity of an insurance domain to test with.
 
     """
+
+    server_name_for_this_server = INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
         super().prepare(reactor, clock, homeserver)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,418 @@
+# Copyright (C) 2025 Famedly
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+import json
+
+from synapse.server import HomeServer
+from synapse.util import Clock
+from twisted.internet import defer
+from twisted.internet.testing import MemoryReactor
+
+from synapse_invite_checker import InviteChecker
+from synapse_invite_checker.types import (
+    Contact,
+    GroupName,
+    InviteSettings,
+    PermissionConfig,
+)
+from tests.base import ModuleApiTestCase
+from tests.test_utils import INSURANCE_DOMAIN_IN_LIST
+from tests.unittest import TestCase
+
+
+def strip_json_of_whitespace(test_json) -> str:
+    """
+    Canonicalize the JSON, so any given values are in the same place
+    """
+    return json.dumps(
+        json.loads(test_json),
+        # This strips whitespace from around the separators
+        separators=(",", ":"),
+        # Guarantee all keys are always in the same order
+        sort_keys=True,
+    )
+
+
+def assert_test_json_matches_permissions(test_json, permissions) -> None:
+    """
+    Test assert that stripping all the whitespace and sorting keys of the json yields
+    the same json after it has passed through the PermissionConfig
+    """
+    test_json_stripped = strip_json_of_whitespace(test_json)
+    assert test_json_stripped == strip_json_of_whitespace(
+        permissions.model_dump_json(exclude_unset=True, exclude_defaults=True)
+    )
+
+
+class PermissionConfigTest(TestCase):
+    def test_model_validate_permissions_default(self) -> None:
+        test_json = '{"defaultSetting": "allow all"}'
+        test_permission_object = PermissionConfig.model_validate_json(test_json)
+
+        assert test_permission_object.is_allow_all()
+        assert not test_permission_object.is_group_excepted(GroupName.isInsuredPerson)
+
+        assert test_permission_object.is_mxid_allowed_to_contact(
+            "@bob:example.com", is_mxid_epa=False
+        )
+        assert_test_json_matches_permissions(test_json, test_permission_object)
+
+        test_json = '{"defaultSetting": "block all"}'
+        test_permission_object = PermissionConfig.model_validate_json(test_json)
+
+        assert not test_permission_object.is_allow_all()
+        assert not test_permission_object.is_group_excepted(GroupName.isInsuredPerson)
+
+        assert not test_permission_object.is_mxid_allowed_to_contact(
+            "@bob:example.com", is_mxid_epa=False
+        )
+        assert_test_json_matches_permissions(test_json, test_permission_object)
+
+    def test_model_validate_permissions_complete(self) -> None:
+        """
+        Test complete forms with both "block all" and "allow all" behaviors. These both
+        test with JSON and with a Dict. The both tests are relevant in that the
+        PermissionConfig defines additional fields that if unused won't be None, and can
+        not be in later JSON used by the account_data system.
+        """
+        # block all section
+        test_json = """
+        {
+            "defaultSetting": "block all",
+            "serverExceptions":
+                {
+                    "power.rangers": {}
+                },
+            "groupExceptions":
+                [{
+                    "groupName": "isInsuredPerson"
+                }],
+            "userExceptions":
+                {
+                    "@david:hassel.hoff": {}
+                }
+        }
+        """
+        test_permission_object = PermissionConfig.model_validate_json(test_json)
+
+        self.assertIn("power.rangers", test_permission_object.serverExceptions)
+        self.assertIn("@david:hassel.hoff", test_permission_object.userExceptions)
+
+        assert not test_permission_object.is_allow_all()
+        assert test_permission_object.is_group_excepted(GroupName.isInsuredPerson)
+        assert test_permission_object.is_mxid_allowed_to_contact(
+            "@david:hassel.hoff", is_mxid_epa=False
+        )
+        assert test_permission_object.is_mxid_allowed_to_contact(
+            "@billy:power.rangers", is_mxid_epa=False
+        )
+        # TODO: make sure this is right
+        assert test_permission_object.is_mxid_allowed_to_contact(
+            f"@patient:{INSURANCE_DOMAIN_IN_LIST}", is_mxid_epa=True
+        )
+
+        assert_test_json_matches_permissions(test_json, test_permission_object)
+
+        test_dict = {
+            "defaultSetting": "block all",
+            "serverExceptions": {"power.rangers": {}},
+            "groupExceptions": [{"groupName": "isInsuredPerson"}],
+            "userExceptions": {"@david:hassel.hoff": {}},
+        }
+
+        test_permission_object = PermissionConfig.model_validate(test_dict)
+
+        self.assertIn("power.rangers", test_permission_object.serverExceptions)
+        self.assertIn("@david:hassel.hoff", test_permission_object.userExceptions)
+        self.assertDictEqual(test_dict, test_permission_object.dump())
+
+        assert not test_permission_object.is_allow_all()
+        assert test_permission_object.is_mxid_allowed_to_contact(
+            "@david:hassel.hoff", is_mxid_epa=False
+        )
+        assert test_permission_object.is_mxid_allowed_to_contact(
+            "@billy:power.rangers", is_mxid_epa=False
+        )
+        # TODO: Make sure this is right
+        assert test_permission_object.is_mxid_allowed_to_contact(
+            f"@patient:{INSURANCE_DOMAIN_IN_LIST}", is_mxid_epa=True
+        )
+        assert test_permission_object.is_group_excepted(GroupName.isInsuredPerson)
+
+        # allow all section
+        test_json = """
+                {
+                    "defaultSetting": "allow all",
+                    "serverExceptions":
+                        {
+                            "power.rangers": {}
+                        },
+                    "groupExceptions":
+                        [{
+                            "groupName": "isInsuredPerson"
+                        }],
+                    "userExceptions":
+                        {
+                            "@david:hassel.hoff": {}
+                        }
+                }
+                """
+        test_permission_object = PermissionConfig.model_validate_json(test_json)
+
+        self.assertIn("power.rangers", test_permission_object.serverExceptions)
+        self.assertIn("@david:hassel.hoff", test_permission_object.userExceptions)
+
+        assert test_permission_object.is_allow_all()
+        assert not test_permission_object.is_mxid_allowed_to_contact(
+            "@david:hassel.hoff", is_mxid_epa=False
+        )
+        assert not test_permission_object.is_mxid_allowed_to_contact(
+            "@billy:power.rangers", is_mxid_epa=False
+        )
+        assert not test_permission_object.is_mxid_allowed_to_contact(
+            f"@patient:{INSURANCE_DOMAIN_IN_LIST}", is_mxid_epa=True
+        )
+
+        assert_test_json_matches_permissions(test_json, test_permission_object)
+
+        test_dict = {
+            "defaultSetting": "allow all",
+            "serverExceptions": {"power.rangers": {}},
+            "groupExceptions": [{"groupName": "isInsuredPerson"}],
+            "userExceptions": {"@david:hassel.hoff": {}},
+        }
+
+        test_permission_object = PermissionConfig.model_validate(test_dict)
+
+        self.assertIn("power.rangers", test_permission_object.serverExceptions)
+        self.assertIn("@david:hassel.hoff", test_permission_object.userExceptions)
+        self.assertDictEqual(test_dict, test_permission_object.dump())
+
+        assert test_permission_object.is_allow_all()
+        assert not test_permission_object.is_mxid_allowed_to_contact(
+            "@david:hassel.hoff", is_mxid_epa=False
+        )
+        assert not test_permission_object.is_mxid_allowed_to_contact(
+            "@billy:power.rangers", is_mxid_epa=False
+        )
+        assert not test_permission_object.is_mxid_allowed_to_contact(
+            f"@patient:{INSURANCE_DOMAIN_IN_LIST}", is_mxid_epa=True
+        )
+
+    def test_model_validate_permissions_scenarios(self) -> None:
+        """
+        Test both with "block_all" and "allow_all" in various scenarios
+        """
+        # scenarios
+        # 1. a doctor(HBA) has allowed all contact but restricted insured actors
+        # 2. an organization user has allowed all contact, but doesn't want to hear from
+        #    a pharmacy domain that continuously misreads orders
+        # 3. a patient has allowed all, but doesn't want to talk to that weird doctor
+        # 4. a doctor has allowed all except insured and forgot he had blocked a specific patient
+
+        # scenario 1
+        test_json = """
+        {
+            "defaultSetting": "allow all",
+            "groupExceptions":
+                [{
+                    "groupName": "isInsuredPerson"
+                }]
+        }
+        """
+        test_permission_object = PermissionConfig.model_validate_json(test_json)
+
+        assert test_permission_object.is_allow_all()
+        # insured are denied
+        assert not test_permission_object.is_mxid_allowed_to_contact(
+            f"@patient:{INSURANCE_DOMAIN_IN_LIST}", is_mxid_epa=True
+        )
+        # everyone else is ok
+        assert test_permission_object.is_mxid_allowed_to_contact(
+            "@billy:power.rangers", is_mxid_epa=False
+        )
+
+        assert_test_json_matches_permissions(test_json, test_permission_object)
+
+        # scenario 2
+        test_json = """
+        {
+            "defaultSetting": "allow all",
+            "serverExceptions":
+                {
+                    "pharmacy.com": {}
+                }
+        }
+        """
+        test_permission_object = PermissionConfig.model_validate_json(test_json)
+
+        assert test_permission_object.is_allow_all()
+        assert not test_permission_object.is_mxid_allowed_to_contact(
+            "@needsglasses:pharmacy.com", is_mxid_epa=False
+        )
+        assert test_permission_object.is_mxid_allowed_to_contact(
+            "@twentytwentyvision:otherpharmacy.com", is_mxid_epa=False
+        )
+
+        assert_test_json_matches_permissions(test_json, test_permission_object)
+
+        # scenario 3
+        test_json = """
+        {
+            "defaultSetting": "allow all",
+            "userExceptions":
+                {
+                    "@badbreath:doctors.edu": {}
+                }
+        }
+        """
+        test_permission_object = PermissionConfig.model_validate_json(test_json)
+
+        assert test_permission_object.is_allow_all()
+        assert not test_permission_object.is_mxid_allowed_to_contact(
+            "@badbreath:doctors.edu", is_mxid_epa=False
+        )
+        assert test_permission_object.is_mxid_allowed_to_contact(
+            "@mothertheresa:doctors.edu", is_mxid_epa=False
+        )
+
+        assert_test_json_matches_permissions(test_json, test_permission_object)
+
+        # scenario 4
+        test_json = """
+        {
+            "defaultSetting": "allow all",
+            "userExceptions":
+                {
+                    "@patient:insured.com": {}
+                },
+            "groupExceptions":
+                [{
+                    "groupName": "isInsuredPerson"
+                }]
+        }
+        """
+        test_permission_object = PermissionConfig.model_validate_json(test_json)
+
+        assert test_permission_object.is_allow_all()
+        # Even though this patient permission exists, they are still blocked
+        assert not test_permission_object.is_mxid_allowed_to_contact(
+            "@patient:insured.com", is_mxid_epa=True
+        )
+        assert not test_permission_object.is_mxid_allowed_to_contact(
+            "@ghandi:insured.com", is_mxid_epa=True
+        )
+
+        assert_test_json_matches_permissions(test_json, test_permission_object)
+
+
+class PermissionsForcedMigrationTestCase(ModuleApiTestCase):
+    def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
+        super().prepare(reactor, clock, homeserver)
+
+        # An unfortunate side effect of side loading the InviteChecker(or any module)
+        # is that it then runs it's startup routines twice. This is subpar, but this test
+        # takes care that the test data is injected after that startup has run.
+        # Unfortunately, Synapse has not provided a way to access these kinds of modules
+        # loaded into it's context; this is what we have to work with.
+        self.invchecker = InviteChecker(
+            self.hs.config.modules.loaded_modules[0][1], self.hs.get_module_api()
+        )
+
+        # users
+        self.user_a = self.register_user("a", "password")
+        self.user_b = self.register_user("b", "password")
+
+        # various contacts for 'a'
+        self.contact_alice = Contact(
+            displayName="Alice",
+            mxid="@alice:example.com",
+            inviteSettings=InviteSettings(start=0, end=None),
+        )
+        self.contact_bob = Contact(
+            displayName="Bob",
+            mxid="@bob:fakeserver.com",
+            inviteSettings=InviteSettings(start=0, end=None),
+        )
+        self.contact_charlie = Contact(
+            displayName="Charlie",
+            mxid="@charlie:some-other-server.com",
+            inviteSettings=InviteSettings(start=0, end=None),
+        )
+        # various contacts for 'b'
+        self.contact_darren = Contact(
+            displayName="Darren",
+            mxid="@darren:fakeserver.com",
+            inviteSettings=InviteSettings(start=0, end=None),
+        )
+        self.contact_elliott = Contact(
+            displayName="Elliott",
+            mxid="@elliot:example.com",
+            inviteSettings=InviteSettings(start=0, end=None),
+        )
+
+        self.get_success(self.invchecker.store.ensure_table_exists())
+        self.get_success(
+            self.invchecker.store.add_contact(self.user_a, self.contact_alice)
+        )
+        self.get_success(
+            self.invchecker.store.add_contact(self.user_a, self.contact_bob)
+        )
+
+        self.get_success(
+            self.invchecker.store.add_contact(self.user_a, self.contact_charlie)
+        )
+        self.get_success(
+            self.invchecker.store.add_contact(self.user_b, self.contact_darren)
+        )
+        self.get_success(
+            self.invchecker.store.add_contact(self.user_b, self.contact_elliott)
+        )
+
+    def test_startup_contact_migration(self) -> None:
+        # test table exists, because above
+        table_exists = self.get_success_or_raise(
+            self.invchecker.store.table_exists(True)
+        )
+        self.assertTrue(table_exists, "Beginning table exists")
+        # test get contacts, should have 2 owners in list
+        owner_contacts = self.get_success_or_raise(
+            self.invchecker.store.get_all_contact_owners_for_migration()
+        )
+
+        self.assertEquals(
+            len(owner_contacts),
+            2,
+            "should have been 2, where did they go?",
+        )
+        # trigger force migration
+        migration_deferred = defer.maybeDeferred(self.invchecker.after_startup)
+        self.get_success_or_raise(migration_deferred)
+
+        # test get contacts, should have 0 for any
+        owner_contacts = self.get_success_or_raise(
+            self.invchecker.store.get_all_contact_owners_for_migration()
+        )
+
+        self.assertEquals(
+            len(owner_contacts),
+            0,
+            "should have been 0, where did they come from?",
+        )
+
+        # let's just make sure
+        table_exists = self.get_success_or_raise(
+            (self.invchecker.store.table_exists(True))
+        )
+        self.assertFalse(table_exists, "Table should be gone at end")

--- a/tests/test_remote_invites.py
+++ b/tests/test_remote_invites.py
@@ -21,7 +21,11 @@ from twisted.internet import defer
 from twisted.internet.testing import MemoryReactor
 
 from tests.base import ModuleApiTestCase
-from tests.test_utils import DOMAIN_IN_LIST, INSURANCE_DOMAIN_IN_LIST
+from tests.test_utils import (
+    DOMAIN_IN_LIST,
+    INSURANCE_DOMAIN_IN_LIST,
+    INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL,
+)
 
 
 class RemoteProModeInviteTest(ModuleApiTestCase):
@@ -283,6 +287,8 @@ class RemoteEpaModeInviteTest(ModuleApiTestCase):
     which will require assuming the identity of an insurance domain to test with.
 
     """
+
+    server_name_for_this_server = INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
         super().prepare(reactor, clock, homeserver)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,147 @@
+from parameterized import parameterized_class
+from synapse.server import HomeServer
+from synapse.storage.database import make_conn
+from synapse.util import Clock
+from twisted.internet.testing import MemoryReactor
+
+from synapse_invite_checker.store import InviteCheckerStore
+from synapse_invite_checker.types import Contact, InviteSettings
+from tests.base import ModuleApiTestCase
+
+
+@parameterized_class([{"use_table": True}, {"use_table": False}])
+class InviteStoreTests(ModuleApiTestCase):
+    """
+    Test having and not having the table doesn't stop the world
+    """
+
+    use_table = False
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
+        super().prepare(reactor, clock, homeserver)
+        api = homeserver.get_module_api()
+
+        dbconfig = None
+        for dbconf in api._store.config.database.databases:
+            if dbconf.name == "master":
+                dbconfig = dbconf
+
+        if not dbconfig:
+            msg = "missing database config"
+            raise Exception(msg)
+
+        with make_conn(
+            dbconfig, api._store.database_engine, "invite_checker_startup"
+        ) as db_conn:
+            self.store = InviteCheckerStore(api._store.db_pool, db_conn, api._hs)
+
+        self.user_a = self.register_user("a", "password")
+
+        self.contact = Contact(
+            displayName="Bob",
+            mxid="@bob:fakeserver.com",
+            inviteSettings=InviteSettings(start=0, end=None),
+        )
+        self.contact_mxid = self.contact.mxid
+
+    def test_add_and_get_and_del_contact(self) -> None:
+        """
+        Specifically for a single contact
+        """
+        if self.use_table:
+            self.get_success(self.store.ensure_table_exists())
+
+        # check contact entry does not exist
+        self.assertEqual(
+            self.get_success(self.store.get_contact(self.user_a, self.contact_mxid)),
+            None,
+            "Contact should not be present",
+        )
+
+        # Try to add the contact
+        self.get_success(self.store.add_contact(self.user_a, self.contact))
+
+        # check contact might be present depending on db_exists
+        self.assertEqual(
+            self.get_success(self.store.get_contact(self.user_a, self.contact_mxid)),
+            self.contact if self.use_table else None,
+            "Contact might be present",
+        )
+
+        # Try and delete contact
+        self.get_success(self.store.del_contact(self.user_a, self.contact_mxid))
+
+        # check contact definitely is gone
+        self.assertEqual(
+            self.get_success(self.store.get_contact(self.user_a, self.contact_mxid)),
+            None,
+            "Contact is not present",
+        )
+
+    def test_get_and_del_contacts(self) -> None:
+        """
+        Specifically for multiple contacts
+        """
+        if self.use_table:
+            self.get_success(self.store.ensure_table_exists())
+
+        # Try and get contacts, should be none
+        stuff = self.get_success(self.store.get_contacts(self.user_a))
+        self.assertEquals(stuff, None)
+
+        # create a few contacts
+        contacts_list = [
+            ("Alice", "@alice:example.com", 0, None),
+            ("Bob", "@bob:fake.com", 0, 400),
+            ("Charlie", "@charlie:example.com", 0, None),
+        ]
+        control_contacts = list(
+            [
+                Contact(
+                    displayName=name,
+                    mxid=mxid,
+                    inviteSettings=InviteSettings(start=start, end=end),
+                )
+                for (name, mxid, start, end) in contacts_list
+            ]
+        )
+        # add them
+        for contact in control_contacts:
+            self.get_success(self.store.add_contact(self.user_a, contact))
+
+        # get them, results vary
+        result_contacts = self.get_success(self.store.get_contacts(self.user_a))
+        assert result_contacts is None if not self.use_table else True
+        if self.use_table:
+            self.assertEqual(result_contacts.contacts, control_contacts)
+        else:
+            self.assertIs(result_contacts, None)
+
+        # drop them
+        self.get_success(self.store.del_contacts(self.user_a))
+
+        # get them again, no results
+        stuff = self.get_success(self.store.get_contacts(self.user_a))
+        self.assertEquals(stuff, None)
+
+    def test_table_exists_and_drop(self) -> None:
+        self.assertEquals(
+            self.get_success_or_raise(self.store.table_exists(True)),
+            False,
+            "Table should not exist at beginning",
+        )
+        if self.use_table:
+            self.get_success_or_raise(self.store.ensure_table_exists())
+
+        self.assertEquals(
+            self.get_success_or_raise(self.store.table_exists(True)),
+            True if self.use_table else False,
+            self.use_table,
+        )
+
+        self.get_success_or_raise(self.store.drop_table())
+        self.assertEquals(
+            self.get_success_or_raise(self.store.table_exists(True)),
+            False,
+            "Table should not exist at end",
+        )

--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -41,8 +41,10 @@ TV = TypeVar("TV")
 SERVER_NAME_FROM_LIST = "tim.test.gematik.de"
 # Use a domain found in our raw fedlist data instead of inserting a fake one
 DOMAIN_IN_LIST = "timo.staging.famedly.de"
-# Also borrow an 'isInsurance' domain for testing
+# Also borrow an 'isInsurance' domain for testing remotes
 INSURANCE_DOMAIN_IN_LIST = "cirosec.de"
+# And another 'isInsurance' domain for testing local
+INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL = "ti-messengertest.dev.ccs.gematik.solutions"
 
 
 def get_awaitable_result(awaitable: Awaitable[TV]) -> TV:

--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -81,8 +81,10 @@ from tests.server import (
 )
 from tests.test_utils import event_injection, setup_awaitable_errors
 from tests.test_utils.logging_setup import setup_logging
-from tests.utils import checked_cast, default_config
+from tests.utils import checked_cast, default_config, setupdb
 
+
+setupdb()
 setup_logging()
 
 TV = TypeVar("TV")


### PR DESCRIPTION
Fixes:
* #25 

Setup a new handler for permissions in Synapse's account data. 
* [x] Stop using the database to store new contact entries
* [x] On first start up, migrate all contact entries to account_data and the new permissions handler.
  * <b>See data loss disclaimer below.</b>
  * <b>NOTE: This effectively makes that user's data instantly available to the client app as account data.</b>
* [x] The Contacts REST API can continue to be used only in "block all" mode, provided that adding a new user is the only change. <b>See data loss disclaimer below.</b>
* [x] As migration takes place for a user the database entries for that user will be deleted
* [x] new tests

Disclaimers:
* I do not know what to do about the data loss that will occur because of this. The hint of `displayName` is the more concerning of these. Does the client app have a way to find that piece of information even if they do not have access to the public profile on the remote server(excepting when there is already a shared room between the users, which feels like a dead end scenario). Loss of `start` and `end` times in the `InviteSettings` I'm more ok with.
* <del>Upstream concern: The account data being set requires an "event type" to be set. For ePA and HBA users, this has been described in the gematik spec. For Users that are neither of those, there is no "event type" established. I have generated one to use for now based on surround criteria</del> I mis read how this works, ignore
* <del>Upstream concern: I have witnessed circumstantial evidence saying there are times that an HBA may not have used their HBA access card(?) to access their account when logging in. If this is true, then I am not sure if there is a concern or not that they may not be on the localization data as `pract` which is a requirement for being a publicly visible HBA. That I know of, I have on other way to discover which type of User is being used to determine the "event type" described immediately above. Might there be an issue where the new permissions in account data won't become accessible if this switch changes?</del> Same reason as above