### PR TITLE
Check and limit room version when creating a room

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ modules:
         federation_list_client_cert: "tests/certs/client.pem", # path to a pem encoded client certificate for mtls, required if federation list url is https
         gematik_ca_baseurl: "https://download-ref.tsl.ti-dienste.de/", # the baseurl to the ca to use for the federation list, required
         tim-type: "epa" or "pro", # Patient/Insurance or Professional mode, defaults to "pro" mode. Optional currently, but will be required in a later release
+        allowed_room_versions: # The list(as strings) of allowed room versions. Currently optional, defaults are listed
+          - "9"
+          - "10"
 ```
 
 ## Testing

--- a/synapse_invite_checker/config.py
+++ b/synapse_invite_checker/config.py
@@ -12,7 +12,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from synapse_invite_checker.types import TimType
 
@@ -27,3 +27,4 @@ class InviteCheckerConfig:
     federation_localization_url: str = ""
     gematik_ca_baseurl: str = ""
     tim_type: TimType = TimType.PRO
+    allowed_room_versions: list[str] = field(default_factory=list)

--- a/tests/base.py
+++ b/tests/base.py
@@ -310,6 +310,8 @@ class ModuleApiTestCase(synapsetest.HomeserverTestCase):
         )
 
     def default_config(self) -> dict[str, Any]:
+        # Explicitly set the 'default_room_version', as the upstream default may change
+        # and that won't be valid for gematik spec
         conf = super().default_config()
         if "modules" not in conf:
             conf["modules"] = [
@@ -321,9 +323,11 @@ class ModuleApiTestCase(synapsetest.HomeserverTestCase):
                         "federation_localization_url": "http://dummy.test/localization",
                         "federation_list_client_cert": "tests/certs/client.pem",
                         "gematik_ca_baseurl": "https://download-ref.tsl.ti-dienste.de/",
+                        "allowed_room_versions": ["9", "10"],
                     },
                 }
             ]
+        conf["default_room_version"] = "10"
         return conf
 
     def add_a_contact_to_user_by_token(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,6 +37,7 @@ class ConfigParsingTestCase(TestCase):
         "federation_localization_url": "https://localhost:8000/localization",
         "federation_list_client_cert": "tests/certs/client.pem",
         "gematik_ca_baseurl": "https://download-ref.tsl.ti-dienste.de/",
+        "allowed_room_versions": ["9", "10"],
     }
 
     def test_tim_type_is_not_case_sensitive(self) -> None:
@@ -107,3 +108,33 @@ class ConfigParsingTestCase(TestCase):
         test_config = self.config.copy()
         test_config.update({"federation_list_url": "https://fake-localhost:8080"})
         self.assertRaises(Exception, InviteChecker.parse_config, test_config)
+
+    def test_allowed_room_versions_is_not_a_list(self) -> None:
+        test_config = self.config.copy()
+        # test_config.update({"allowed_room_versions": "['9', '10']"})
+
+        assert InviteChecker.parse_config(test_config)
+
+        # Nope, not a list
+        test_config.update({"allowed_room_versions": "9"})
+        self.assertRaises(ConfigError, InviteChecker.parse_config, test_config)
+
+        # Nope, not a list
+        test_config.update({"allowed_room_versions": "{9}"})
+        self.assertRaises(ConfigError, InviteChecker.parse_config, test_config)
+
+        # Nope, not a recognized list
+        test_config.update({"allowed_room_versions": "9, 10"})
+        self.assertRaises(ConfigError, InviteChecker.parse_config, test_config)
+
+        # Nope, not a list
+        test_config.update({"allowed_room_versions": "9 10"})
+        self.assertRaises(ConfigError, InviteChecker.parse_config, test_config)
+
+        # This one is okay, these are integers and can be coerced into strings
+        test_config.update({"allowed_room_versions": [9, 10]})  # type: ignore[arg-type]
+        assert InviteChecker.parse_config(test_config)
+
+        # This is allowed
+        test_config.update({"allowed_room_versions": ["8"]})
+        assert InviteChecker.parse_config(test_config)

--- a/tests/test_room_versions.py
+++ b/tests/test_room_versions.py
@@ -1,0 +1,123 @@
+# Copyright (C) 2025 Famedly
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+import contextlib
+from http import HTTPStatus
+
+from synapse.server import HomeServer
+from synapse.util import Clock
+from twisted.internet.testing import MemoryReactor
+
+from tests.base import ModuleApiTestCase, construct_extra_content
+
+
+class RoomVersionCreateRoomTest(ModuleApiTestCase):
+    """
+    Tests for limiting room versions when creating rooms. Use the defaults of room
+    versions "9" or "10"
+    """
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
+        super().prepare(reactor, clock, homeserver)
+
+        self.user_a = self.register_user("a", "password")
+        self.access_token_a = self.login("a", "password")
+
+    def user_create_room(
+        self,
+        invitee_list: list[str] | None = None,
+        is_public: bool = False,
+        room_ver: str | int = None,
+        expect_code: int = HTTPStatus.OK,
+    ) -> str | None:
+        """
+        Helper to send an api request with a full set of required additional room state
+        to the room creation matrix endpoint. Returns a room_id if successful
+        """
+        # Hide the assertion from create_room_as() when the error code is unexpected. It
+        # makes errors for the tests less clear when all we get is the http response
+        with contextlib.suppress(AssertionError):
+            return self.helper.create_room_as(
+                self.user_a,
+                is_public=is_public,
+                room_version=room_ver,
+                tok=self.access_token_a,
+                expect_code=expect_code,
+                extra_content=construct_extra_content(self.user_a, invitee_list or []),
+            )
+        return None
+
+    def test_create_room_fails(self) -> None:
+        """
+        Test that most generic ways of not doing a room version string, and a room
+        version that is outside of what is wanted, fail
+        """
+        self.assertIsNone(
+            self.user_create_room(
+                [],
+                is_public=False,
+                room_ver="8",
+                expect_code=HTTPStatus.BAD_REQUEST,
+            )
+        )
+        self.assertIsNone(
+            self.user_create_room(
+                [],
+                is_public=False,
+                room_ver=8,
+                expect_code=HTTPStatus.BAD_REQUEST,
+            )
+        )
+
+        self.assertIsNone(
+            self.user_create_room(
+                [],
+                is_public=False,
+                room_ver="11",
+                expect_code=HTTPStatus.BAD_REQUEST,
+            )
+        )
+        self.assertIsNone(
+            self.user_create_room(
+                [],
+                is_public=False,
+                room_ver=11,
+                expect_code=HTTPStatus.BAD_REQUEST,
+            )
+        )
+        self.assertIsNone(
+            self.user_create_room(
+                [],
+                is_public=False,
+                room_ver="bad_version",
+                expect_code=HTTPStatus.BAD_REQUEST,
+            )
+        )
+
+    def test_create_room_succeeds(self) -> None:
+        """
+        Tests that a room version that is allowed succeeds
+        """
+        assert self.user_create_room(
+            [],
+            is_public=False,
+            room_ver="9",
+            expect_code=HTTPStatus.OK,
+        )
+        assert self.user_create_room(
+            [],
+            is_public=False,
+            room_ver="10",
+            expect_code=HTTPStatus.OK,
+        )

--- a/tests/test_tim_information.py
+++ b/tests/test_tim_information.py
@@ -44,6 +44,7 @@ class MessengerInfoTestCase(ModuleApiTestCase):
                         "federation_localization_url": "https://localhost:8000/localization",
                         "federation_list_client_cert": "tests/certs/client.pem",
                         "gematik_ca_baseurl": "https://download-ref.tsl.ti-dienste.de/",
+                        "allowed_room_versions": ["9", "10"],
                     },
                 }
             ]
@@ -101,6 +102,7 @@ class MessengerIsInsuranceResourceTest(ModuleApiTestCase):
                         "federation_localization_url": "https://localhost:8000/localization",
                         "federation_list_client_cert": "tests/certs/client.pem",
                         "gematik_ca_baseurl": "https://download-ref.tsl.ti-dienste.de/",
+                        "allowed_room_versions": ["9", "10"],
                     },
                 }
             ]


### PR DESCRIPTION
This will add a check into the `on_create_room()` for verifying that the room version requested is allowed.

New configuration setting: `allowed_room_versions` which needs to be set as a list

```
allowed_room_versions:
- "9"
- "10"
```

helps with 
* famedly/product-management#2824