### PR TITLE
Check room version requested when upgrading a room

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,9 @@ dependencies = [
   "mock",
   "parameterized",
   "psycopg2",
-  "matrix-synapse" # we don't depend on synapse directly to prevent pip from pulling the wrong synapse, when we just want to install the module
+  # we don't depend on synapse directly to prevent pip from pulling the wrong synapse,
+  # when we just want to install the module
+  "matrix-synapse @ git+https://github.com/famedly/synapse.git@master"
 ]
 [tool.hatch.envs.default.scripts]
 cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=synapse_invite_checker --cov=tests"

--- a/tests/base.py
+++ b/tests/base.py
@@ -27,6 +27,7 @@ from synapse.rest.client import (
     presence,
     profile,
     room,
+    room_upgrade_rest_servlet,
 )
 from synapse.server import HomeServer
 from synapse.util import Clock
@@ -275,6 +276,7 @@ class ModuleApiTestCase(synapsetest.HomeserverTestCase):
         account_data.register_servlets,
         login.register_servlets,
         room.register_servlets,
+        room_upgrade_rest_servlet.register_servlets,
         presence.register_servlets,
         profile.register_servlets,
         notifications.register_servlets,


### PR DESCRIPTION
...and deny it based on the existing configuration setting `allowed_room_versions`

Depends on 
* famedly/synapse#18

Resolves 
* famedly/product-management#2824