### PR TITLE
Scan and purge inactive rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ modules:
         insured_only_room_scan:
           enabled: true or false  # optional switch to disable the insured-only room scan from running.  The scan is enabled by default, but only runs in EPA mode, otherwise this option is ignored and the scan is disabled.
           grace_period: see 'Duration Parsing' below, # Length of time a room with only EPA members is allowed to exist before deletion. Ignored if `enabled` is false. Defaults to "1w"
+        inactive_room_scan:
+          enabled: true or false # optional switch to disable the room scan for inactive rooms, defaults to true
+          grace_period: see 'Duration Parsing' below # Length of time a room is allowed to have no message activity before it is eligible for deletion. Ignored if 'enabled' is false. Defaults to "26w" which is 6 months
 ```
 ### Duration Parsing
 Settings labeled as 'duration_parsing' allow for a string representation of the value

--- a/synapse_invite_checker/config.py
+++ b/synapse_invite_checker/config.py
@@ -24,6 +24,12 @@ class InsuredOnlyRoomScanConfig:
 
 
 @dataclass
+class InactiveRoomScanConfig:
+    grace_period_ms: int = 0
+    enabled: bool = False
+
+
+@dataclass
 class InviteCheckerConfig:
     title: str = "Invite Checker module by Famedly"
     description: str = "Invite Checker module by Famedly"
@@ -37,4 +43,7 @@ class InviteCheckerConfig:
     room_scan_run_interval_ms: int = 0
     insured_room_scan_options: InsuredOnlyRoomScanConfig = field(
         default_factory=InsuredOnlyRoomScanConfig
+    )
+    inactive_room_scan_options: InactiveRoomScanConfig = field(
+        default_factory=InactiveRoomScanConfig
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -153,7 +153,7 @@ class ConfigParsingTestCase(TestCase):
         test_config.update({"room_scan_run_interval": "why"})
         self.assertRaises(ValueError, InviteChecker.parse_config, test_config)
 
-    def test_incorrect_insured_only_room_scan_type_raises(self) -> None:
+    def test_dict_unexpectedly_is_something_else_raises(self) -> None:
         test_config = self.config.copy()
         # Shouldn't work if set to a string
         test_config.update({"insured_only_room_scan": "bad value"})
@@ -161,4 +161,15 @@ class ConfigParsingTestCase(TestCase):
 
         # Shouldn't work if set to a
         test_config.update({"insured_only_room_scan": ["what", "is", "a", "list?"]})
+        self.assertRaises(ConfigError, InviteChecker.parse_config, test_config)
+
+        test_config = self.config.copy()
+        # Shouldn't work if set to a string
+        test_config.update({"inactive_room_scan": "not a dict"})
+        self.assertRaises(ConfigError, InviteChecker.parse_config, test_config)
+
+        # Shouldn't work if set to a
+        test_config.update(
+            {"inactive_room_scan": ["lists", "are", "only", "good", "on", "mondays"]}
+        )
         self.assertRaises(ConfigError, InviteChecker.parse_config, test_config)

--- a/tests/test_room_message_timestamp.py
+++ b/tests/test_room_message_timestamp.py
@@ -1,0 +1,107 @@
+# Copyright (C) 2025 Famedly
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+import logging
+
+from synapse.server import HomeServer
+from synapse.util import Clock
+from twisted.internet.testing import MemoryReactor
+
+from tests.base import ModuleApiTestCase
+
+
+logger = logging.getLogger(__name__)
+
+
+class MessageTimestampTestCase(ModuleApiTestCase):
+    def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
+        super().prepare(reactor, clock, homeserver)
+        #  @a:test is a practitioner
+        #  @b:test is an organization
+        #  @c:test is an 'orgPract'
+        self.user_a = self.register_user("a", "password")
+        self.access_token_a = self.login("a", "password")
+        self.user_b = self.register_user("b", "password")
+        self.access_token_b = self.login("b", "password")
+        self.user_c = self.register_user("c", "password")
+
+        # @d:test is none of those types of actor and should be just a 'User'. For
+        # context, this could be a chatbot or an office manager
+        self.user_d = self.register_user("d", "password")
+        self.access_token_d = self.login("d", "password")
+
+    def user_a_create_room(
+        self,
+        is_public: bool,
+    ) -> str | None:
+        """
+        Helper to send an api request with a full set of required additional room state
+        to the room creation matrix endpoint.
+        """
+        # Hide the assertion from create_room_as() when the error code is unexpected. It
+        # makes errors for the tests less clear when all we get is the http response
+        return self.helper.create_room_as(
+            self.user_a,
+            is_public=is_public,
+            tok=self.access_token_a,
+        )
+
+    def test_can_find_last_message_timestamp(self) -> None:
+        # self.hs.mockmod: InviteChecker
+        # create a room, add another user
+        # send a message, get the timestamp
+        # send two more messages, get the timestamp
+        # have other user send a message, get that timestamp
+        # have other user send two more messages, and get that timestamp
+
+        def send_message_and_assert_latest_activity(room, message, tok) -> None:
+            body = self.helper.send(room, message, tok=tok)
+
+            event_id = self.helper.get_event(room, body.get("event_id"), tok=tok)
+            event_ts = event_id.get("origin_server_ts")
+
+            ts_found = self.get_success_or_raise(
+                self.hs.mockmod.get_timestamp_of_last_eligible_activity_in_room(room)
+            )
+
+            self.assertEqual(event_ts, ts_found)
+
+        room_id = self.user_a_create_room(is_public=False)
+        assert room_id, "Room created"
+
+        self.helper.invite(room_id, targ=self.user_b, tok=self.access_token_a)
+        self.helper.join(room_id, self.user_b, tok=self.access_token_b)
+
+        send_message_and_assert_latest_activity(
+            room_id, "Message 1", tok=self.access_token_a
+        )
+        self.helper.send(room_id, "Message 2", tok=self.access_token_a)
+
+        send_message_and_assert_latest_activity(
+            room_id, "Message 3", tok=self.access_token_a
+        )
+
+        send_message_and_assert_latest_activity(
+            room_id, "Message 4", tok=self.access_token_b
+        )
+
+        self.helper.send(room_id, "Message 5", tok=self.access_token_b)
+
+        self.helper.send(room_id, "Message 6", tok=self.access_token_b)
+        self.helper.send(room_id, "Message 7", tok=self.access_token_b)
+        self.helper.send(room_id, "Message 8", tok=self.access_token_b)
+        self.helper.send(room_id, "Message 9", tok=self.access_token_b)
+        send_message_and_assert_latest_activity(
+            room_id, "Message 10", tok=self.access_token_b
+        )


### PR DESCRIPTION
Resolves famedly/product-management#2829 

Find and remove inactive rooms. Do this by finding the last actual message in a room and retrieving it's time stamp. In the case that the room never had any messages(either encrypted or clear text), use the room creation event. If it was longer than the `grace_period` below, that room is scheduled for purging using the infrastructure introduced in #43 . 

Frequency of the scan itself is governed by `room_scan_run_interval`

New settings
```yaml
inactive_room_scan:
  enabled: true or false # an optional switch to disable processing of this part of the room scan
  grace_period: 26w # An optional value for how long to keep a room after the last eligible event,
                    # defaults to 6 months("26w"). Uses the 'duration parsing' or a direct millisecond
                    # integer. Ignored if 'enabled' is false
```

New metric available for "Per-block Metrics" section:
* "get_timestamp_of_last_eligible_activity_in_room" will be found on the Synapse worker responsible for background tasks