### PR TITLE
chore: Move the `/tim-information` endpoint from our namespaced area …

### DIFF
--- a/synapse_invite_checker/rest/messenger_info.py
+++ b/synapse_invite_checker/rest/messenger_info.py
@@ -29,7 +29,7 @@ from synapse_invite_checker.types import TimType
 # https://github.com/gematik/api-ti-messenger/blob/main/src/openapi/TiMessengerInformation.yaml
 _TMI_schema_version = "1.0.0"
 
-INFO_API_PREFIX = "/_synapse/client/com.famedly/tim/tim-information"
+INFO_API_PREFIX = "/tim-information"
 
 
 def tim_info_patterns(path_regex: str) -> List[re.Pattern]:

--- a/tests/test_tim_information.py
+++ b/tests/test_tim_information.py
@@ -22,7 +22,8 @@ class MessengerInfoTestCase(ModuleApiTestCase):
 
         channel = self.make_request(
             method="GET",
-            path="/_synapse/client/com.famedly/tim/tim-information",
+            path="/tim-information",
+            shorthand=False,
         )
 
         assert channel.code == 200, channel.result
@@ -55,7 +56,8 @@ class MessengerInfoTestCase(ModuleApiTestCase):
 
         channel = self.make_request(
             method="GET",
-            path="/_synapse/client/com.famedly/tim/tim-information",
+            path="/tim-information",
+            shorthand=False,
         )
 
         assert channel.code == 200, channel.result
@@ -70,7 +72,8 @@ class MessengerIsInsuranceResourceTest(ModuleApiTestCase):
         """Tests that Pro mode returns expected response"""
         channel = self.make_request(
             method="GET",
-            path="/_synapse/client/com.famedly/tim/tim-information/v1/server/isInsurance?serverName=cirosec.de",
+            path="/tim-information/v1/server/isInsurance?serverName=cirosec.de",
+            shorthand=False,
         )
 
         assert channel.code == 200, channel.result
@@ -80,7 +83,8 @@ class MessengerIsInsuranceResourceTest(ModuleApiTestCase):
 
         channel = self.make_request(
             method="GET",
-            path="/_synapse/client/com.famedly/tim/tim-information/v1/server/isInsurance?serverName=timo.staging.famedly.de",
+            path="/tim-information/v1/server/isInsurance?serverName=timo.staging.famedly.de",
+            shorthand=False,
         )
 
         assert channel.code == 200, channel.result
@@ -113,14 +117,16 @@ class MessengerIsInsuranceResourceTest(ModuleApiTestCase):
 
         channel = self.make_request(
             method="GET",
-            path="/_synapse/client/com.famedly/tim/tim-information/v1/server/isInsurance?serverName=cirosec.de",
+            path="/tim-information/v1/server/isInsurance?serverName=cirosec.de",
+            shorthand=False,
         )
 
         assert channel.code == 401, channel.result
 
         channel = self.make_request(
             method="GET",
-            path="/_synapse/client/com.famedly/tim/tim-information/v1/server/isInsurance?serverName=timo.staging.famedly.de",
+            path="/tim-information/v1/server/isInsurance?serverName=timo.staging.famedly.de",
+            shorthand=False,
         )
 
         assert channel.code == 401, channel.result


### PR DESCRIPTION
…closer to the root