### PR TITLE
feat: Configuration setting for default contact permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ modules:
         federation_list_client_cert: "tests/certs/client.pem", # path to a pem encoded client certificate for mtls, required if federation list url is https
         gematik_ca_baseurl: "https://download-ref.tsl.ti-dienste.de/", # the baseurl to the ca to use for the federation list, required
         tim-type: "epa" or "pro", # Patient/Insurance or Professional mode, defaults to "pro" mode. Optional currently, but will be required in a later release
+        default_permission: "allow all" or "block all", # For setting an users initial permission, will not affect existing permissions. Defaults to "block all" for backwards compatibility
         allowed_room_versions: # The list(as strings) of allowed room versions. Currently optional, defaults are listed
           - "9"
           - "10"

--- a/synapse_invite_checker/config.py
+++ b/synapse_invite_checker/config.py
@@ -14,7 +14,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 from dataclasses import dataclass, field
 
-from synapse_invite_checker.types import TimType
+from synapse_invite_checker.types import PermissionDefaultSetting, TimType
 
 
 @dataclass
@@ -39,6 +39,7 @@ class InviteCheckerConfig:
     federation_localization_url: str = ""
     gematik_ca_baseurl: str = ""
     tim_type: TimType = TimType.PRO
+    default_permission: PermissionDefaultSetting = PermissionDefaultSetting.BLOCK_ALL
     allowed_room_versions: list[str] = field(default_factory=list)
     room_scan_run_interval_ms: int = 0
     insured_room_scan_options: InsuredOnlyRoomScanConfig = field(

--- a/synapse_invite_checker/invite_checker.py
+++ b/synapse_invite_checker/invite_checker.py
@@ -78,7 +78,11 @@ from synapse_invite_checker.rest.messenger_info import (
 )
 
 from synapse_invite_checker.store import InviteCheckerStore
-from synapse_invite_checker.types import FederationList, TimType
+from synapse_invite_checker.types import (
+    FederationList,
+    PermissionDefaultSetting,
+    TimType,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -205,6 +209,7 @@ class InviteChecker:
 
         self.permissions_handler = InviteCheckerPermissionsHandler(
             self.api,
+            self.config,
             self.fetch_localization_for_mxid,
             self.is_domain_insurance,
         )
@@ -308,6 +313,16 @@ class InviteChecker:
             else:
                 msg = "`tim-type` setting is not a recognized value. Please fix."
                 raise ConfigError(msg)
+
+        _default_permission = config.get(
+            "default_permission", _config.default_permission.value
+        )
+        try:
+            _coerce_default = PermissionDefaultSetting(_default_permission)
+        except ValueError as e:
+            msg = f"Default permission setting is unrecognized value: '{_default_permission}'"
+            raise ConfigError(msg) from e
+        _config.default_permission = _coerce_default
 
         _allowed_room_versions = config.get("allowed_room_versions", ["9", "10"])
         if not _allowed_room_versions or not isinstance(_allowed_room_versions, list):

--- a/synapse_invite_checker/permissions.py
+++ b/synapse_invite_checker/permissions.py
@@ -17,10 +17,10 @@ from typing import Awaitable, Callable
 from synapse.module_api import ModuleApi
 from synapse.types import UserID
 
+from synapse_invite_checker.config import InviteCheckerConfig
 from synapse_invite_checker.types import (
     PermissionConfig,
     PermissionConfigType,
-    PermissionDefaultSetting,
 )
 
 
@@ -35,10 +35,12 @@ class InviteCheckerPermissionsHandler:
     def __init__(
         self,
         api: ModuleApi,
+        config: InviteCheckerConfig,
         localization_cb: Callable[[str], Awaitable[str]],
         is_domain_insurance_cb: Callable[[str], Awaitable[bool]],
     ) -> None:
         self.api = api
+        self.config = config
         self.account_data_manager = self.api.account_data_manager
         self.fetch_localization_for_mxid = localization_cb
         self.is_domain_insurance = is_domain_insurance_cb
@@ -50,7 +52,7 @@ class InviteCheckerPermissionsHandler:
         )
         if account_data is None:
             permissions = PermissionConfig(
-                defaultSetting=PermissionDefaultSetting.BLOCK_ALL,
+                defaultSetting=self.config.default_permission,
             )
         else:
             permissions = PermissionConfig.model_validate(account_data)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,6 +55,15 @@ class ConfigParsingTestCase(TestCase):
         test_config.update({"tim-type": "fake"})
         self.assertRaises(ConfigError, InviteChecker.parse_config, test_config)
 
+    def test_incorrect_default_permission_raises(self) -> None:
+        test_config = self.config.copy()
+        test_config.update({"default_permission": "reject all"})
+        self.assertRaises(ConfigError, InviteChecker.parse_config, test_config)
+
+        test_config = self.config.copy()
+        test_config.update({"default_permission": "allow_all"})
+        self.assertRaises(ConfigError, InviteChecker.parse_config, test_config)
+
     def test_missing_fed_list_or_gematik_ca_url_raises(self) -> None:
         test_config = self.config.copy()
         test_config.update({"federation_list_url": ""})

--- a/tests/test_createrooms_local.py
+++ b/tests/test_createrooms_local.py
@@ -305,11 +305,12 @@ class LocalEpaModeCreateRoomTest(ModuleApiTestCase):
         # send_notice() will automatically create a server notices room and then invite
         # the user it is directed towards. The server notices manager has no method to
         # invite a user during creation of the room
-        room_id = self.get_success_or_raise(
+        event = self.get_success_or_raise(
             self.hs.get_server_notices_manager().send_notice(
                 self.user_d, {"body": "Server Notice message", "msgtype": "m.text"}
             )
         )
+        room_id = event.room_id
         # Retrieving the room_id is a sign that the room was created, the user was
         # invited, and the message was sent
         assert room_id

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -64,6 +64,9 @@ class InsuredOnlyRoomScanTaskTestCase(FederatingModuleApiTestCase):
 
         conf["modules"][0].setdefault("config", {}).update({"tim-type": "epa"})
         conf["modules"][0].setdefault("config", {}).update(
+            {"default_permission": "allow all"}
+        )
+        conf["modules"][0].setdefault("config", {}).update(
             {"room_scan_run_interval": "1h"}
         )
         conf["modules"][0].setdefault("config", {}).update(
@@ -174,8 +177,6 @@ class InsuredOnlyRoomScanTaskTestCase(FederatingModuleApiTestCase):
         Test that a room is deleted when a single EPA user and a single PRO user are in
         a room, but the PRO user leaves
         """
-        self.add_a_contact_to_user_by_token(self.remote_pro_user, self.access_token_d)
-
         # Make a room and invite the doctor
         room_id = self.user_d_create_room([self.remote_pro_user], is_public=False)
         assert room_id is not None
@@ -255,8 +256,6 @@ class InsuredOnlyRoomScanTaskTestCase(FederatingModuleApiTestCase):
         room, so it's dangling and won't be cleaned up unless `forget_room_on_leave` is
         turned on. I'm not sure I need to test for this?
         """
-        self.add_a_contact_to_user_by_token(self.remote_pro_user, self.access_token_d)
-
         # Make a room and invite the doctor
         room_id = self.user_d_create_room([self.remote_pro_user], is_public=False)
         assert room_id is not None
@@ -324,8 +323,6 @@ class InsuredOnlyRoomScanTaskTestCase(FederatingModuleApiTestCase):
         """
         Test that a room is not deleted until the last PRO user leaves a room
         """
-        self.add_a_contact_to_user_by_token(self.remote_pro_user, self.access_token_d)
-
         # Make a room and invite the doctor
         room_id = self.user_d_create_room([self.remote_pro_user], is_public=False)
         assert room_id is not None
@@ -522,6 +519,9 @@ class InactiveRoomScanTaskTestCase(FederatingModuleApiTestCase):
 
         conf["modules"][0].setdefault("config", {}).update({"tim-type": "pro"})
         conf["modules"][0].setdefault("config", {}).update(
+            {"default_permission": "allow all"}
+        )
+        conf["modules"][0].setdefault("config", {}).update(
             {"room_scan_run_interval": "1h"}
         )
         conf["modules"][0].setdefault("config", {}).update(
@@ -690,12 +690,6 @@ class InactiveRoomScanTaskTestCase(FederatingModuleApiTestCase):
         Test that a room is deleted when a local PRO user and various others don't touch
         a room for "inactive_room_scan.grace_period" amount of time
         """
-        for other_user in other_users:
-            # just unilaterally add the contact, instead of deciding if it's a publicly
-            # visible practitioner or not. NOTE: when moving to ALLOW ALL mode, this
-            # can be removed
-            self.add_a_contact_to_user_by_token(other_user, self.access_token_a)
-
         # Make a room and invite the other occupant(s)
         room_id = self.user_a_create_room([], is_public=is_public)
         assert room_id is not None, "Room should exist"


### PR DESCRIPTION
Per [A_26016](https://gemspec.gematik.de/docs/gemSpec/gemSpec_TI-M_Basis/gemSpec_TI-M_Basis_V1.1.1/#A_26016):
> The TI-M Client MUST allow a TI Messenger provider to predefine the basic permission configuration setting. 

New configuration option:
```
default_permission: "allow all" or "block all"
```
Defaults to "block all" for backwards compatibility. Does not affect existing permissions, only those for new users