### PR TITLE
feat: Forbid local user from joining remote rooms(with no invite)

### DIFF
--- a/tests/test_local_joins.py
+++ b/tests/test_local_joins.py
@@ -1,0 +1,150 @@
+# Copyright (C) 2025 Famedly
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+import logging
+from http import HTTPStatus
+
+from synapse.server import HomeServer
+from synapse.util import Clock
+from twisted.internet.testing import MemoryReactor
+
+from tests.base import ModuleApiTestCase, construct_extra_content
+
+
+logger = logging.getLogger(__name__)
+
+
+class LocalJoinTestCase(ModuleApiTestCase):
+    """
+    Tests to verify that we don't break local public/private rooms by accident
+    """
+
+    # server_name_for_this_server = "tim.test.gematik.de"
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
+        super().prepare(reactor, clock, homeserver)
+        #  "a" is a practitioner
+        #  "b" is an organization
+        #  "c" is an 'orgPract'
+        self.user_a = self.register_user("a", "password")
+        self.access_token_a = self.login("a", "password")
+        self.user_b = self.register_user("b", "password")
+        self.access_token_b = self.login("b", "password")
+        self.user_c = self.register_user("c", "password")
+        self.access_token_c = self.login("c", "password")
+
+        # "d" is none of those types of actor and should be just a 'User'. For
+        # context, this could be a chatbot or an office manager
+        self.user_d = self.register_user("d", "password")
+        self.access_token_d = self.login("d", "password")
+
+        self.user_id_to_token = {
+            self.user_a: self.access_token_a,
+            self.user_b: self.access_token_b,
+            self.user_c: self.access_token_c,
+            self.user_d: self.access_token_d,
+        }
+
+    def user_create_room(
+        self,
+        creating_user: str,
+        invitee_list: list[str],
+        is_public: bool,
+        expected_code: int = HTTPStatus.OK,
+    ) -> str | None:
+        """
+        Helper to send an api request with a full set of required additional room state
+        to the room creation matrix endpoint.
+        """
+        return self.helper.create_room_as(
+            creating_user,
+            is_public=is_public,
+            tok=self.user_id_to_token.get(creating_user),
+            expect_code=expected_code,
+            extra_content=construct_extra_content(creating_user, invitee_list),
+        )
+
+    def test_joining_public_with_invites(self) -> None:
+        """Test joining a local public room with invites is allowed"""
+        room_id = self.user_create_room(self.user_a, [], is_public=True)
+        assert room_id is not None, "Room should have been created"
+
+        self.helper.invite(room_id, self.user_a, self.user_b, tok=self.access_token_a)
+        self.helper.invite(room_id, self.user_a, self.user_c, tok=self.access_token_a)
+        self.helper.invite(room_id, self.user_a, self.user_d, tok=self.access_token_a)
+
+        self.helper.join(room_id, self.user_b, tok=self.access_token_b)
+        self.helper.join(room_id, self.user_c, tok=self.access_token_c)
+        self.helper.join(room_id, self.user_d, tok=self.access_token_d)
+
+    def test_joining_public_no_invites(self) -> None:
+        """Test joining a local public room with no invites is allowed"""
+        room_id = self.user_create_room(self.user_a, [], is_public=True)
+        assert room_id is not None, "Room should have been created"
+
+        self.helper.join(room_id, self.user_b, tok=self.access_token_b)
+        self.helper.join(room_id, self.user_c, tok=self.access_token_c)
+        self.helper.join(room_id, self.user_d, tok=self.access_token_d)
+
+    def test_joining_private_no_invites(self) -> None:
+        """Test joining a local private room with no invites is denied"""
+        room_id = self.user_create_room(self.user_a, [], is_public=False)
+        assert room_id is not None, "Room should have been created"
+
+        self.helper.join(
+            room_id,
+            self.user_b,
+            expect_code=HTTPStatus.FORBIDDEN,
+            tok=self.access_token_b,
+        )
+        self.helper.join(
+            room_id,
+            self.user_c,
+            expect_code=HTTPStatus.FORBIDDEN,
+            tok=self.access_token_c,
+        )
+        self.helper.join(
+            room_id,
+            self.user_d,
+            expect_code=HTTPStatus.FORBIDDEN,
+            tok=self.access_token_d,
+        )
+
+    def test_joining_private_with_invites(self) -> None:
+        """Test joining a local private room with invites is allowed"""
+        room_id = self.user_create_room(self.user_a, [], is_public=False)
+        assert room_id is not None, "Room should have been created"
+
+        self.helper.invite(room_id, self.user_a, self.user_b, tok=self.access_token_a)
+        self.helper.invite(room_id, self.user_a, self.user_c, tok=self.access_token_a)
+        self.helper.invite(room_id, self.user_a, self.user_d, tok=self.access_token_a)
+
+        self.helper.join(
+            room_id,
+            self.user_b,
+            expect_code=HTTPStatus.OK,
+            tok=self.access_token_b,
+        )
+        self.helper.join(
+            room_id,
+            self.user_c,
+            expect_code=HTTPStatus.OK,
+            tok=self.access_token_c,
+        )
+        self.helper.join(
+            room_id,
+            self.user_d,
+            expect_code=HTTPStatus.OK,
+            tok=self.access_token_d,
+        )

--- a/tests/test_remote_joins.py
+++ b/tests/test_remote_joins.py
@@ -1,0 +1,492 @@
+# Copyright (C) 2025 Famedly
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+import logging
+from http import HTTPStatus
+from typing_extensions import override
+from unittest.mock import AsyncMock, Mock
+
+from parameterized import parameterized
+from synapse.server import HomeServer
+from synapse.util import Clock
+from twisted.internet.testing import MemoryReactor
+
+from synapse_invite_checker import InviteChecker
+from tests.base import (
+    FederatingModuleApiTestCase,
+    construct_extra_content,
+)
+from tests.test_utils import DOMAIN_IN_LIST, INSURANCE_DOMAIN_IN_LIST
+
+
+logger = logging.getLogger(__name__)
+
+
+class IncomingRemoteJoinTestCase(FederatingModuleApiTestCase):
+    """
+    Test incoming remote joins(from federation) behave as expected.
+    Unlike tests in test_createrooms_remote.py, these have rooms created with no invites
+    """
+
+    # By default, we are SERVER_NAME_FROM_LIST
+    # server_name_for_this_server = "tim.test.gematik.de"
+    # This test case will model being an PRO server on the federation list
+
+    # Test with two remote PRO user(one hba and one unlisted) and one EPA user
+    remote_hba_user = f"@mxid:{DOMAIN_IN_LIST}"
+    # remote_pro_user = f"unlisted:{DOMAIN_IN_LIST}"
+    remote_epa_user = f"@alice:{INSURANCE_DOMAIN_IN_LIST}"
+    # The default "fake" remote server name that has its server signing keys auto-injected
+    OTHER_SERVER_NAME = DOMAIN_IN_LIST
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
+        super().prepare(reactor, clock, homeserver)
+        #  "a" is a practitioner
+        #  "b" is an organization
+        #  "c" is an 'orgPract'
+        self.user_a = self.register_user("a", "password")
+        self.access_token_a = self.login("a", "password")
+        self.user_b = self.register_user("b", "password")
+        self.access_token_b = self.login("b", "password")
+        self.user_c = self.register_user("c", "password")
+        self.access_token_c = self.login("c", "password")
+
+        # "d" is none of those types of actor and should be just a 'User'. For
+        # context, this could be a chatbot or an office manager
+        self.user_d = self.register_user("d", "password")
+        self.access_token_d = self.login("d", "password")
+
+        self.user_id_to_token = {
+            self.user_a: self.access_token_a,
+            self.user_b: self.access_token_b,
+            self.user_c: self.access_token_c,
+            self.user_d: self.access_token_d,
+        }
+
+        self.inv_checker: InviteChecker = self.hs.mockmod
+
+        # OTHER_SERVER_NAME already has it's signing key injected into our database so
+        # our server doesn't have to make that request. Add the other servers we will be
+        # using as well
+        self.map_server_name_to_signing_key.update(
+            {
+                INSURANCE_DOMAIN_IN_LIST: self.inject_servers_signing_key(
+                    INSURANCE_DOMAIN_IN_LIST
+                ),
+            },
+        )
+
+    def user_create_room(
+        self,
+        creating_user: str,
+        invitee_list: list[str],
+        is_public: bool,
+        expected_code: int = HTTPStatus.OK,
+    ) -> str | None:
+        """
+        Helper to send an api request with a full set of required additional room state
+        to the room creation matrix endpoint.
+        """
+        return self.helper.create_room_as(
+            creating_user,
+            is_public=is_public,
+            tok=self.user_id_to_token.get(creating_user),
+            expect_code=expected_code,
+            extra_content=construct_extra_content(creating_user, invitee_list),
+        )
+
+    @parameterized.expand([("public", True), ("private", False)])
+    def test_local_room_remote_epa_no_invites(self, _: str, is_public: bool) -> None:
+        """
+        Test _with no invites_ behavior for public and private rooms when there is an
+        incoming remote user
+        """
+        if is_public:
+            self.skipTest("Can't block incoming public joins yet")
+
+        room_id = self.user_create_room(self.user_a, [], is_public=is_public)
+        assert room_id is not None, "Room should have been created"
+
+        # public should not succeed
+        # private should also not succeed
+        # Since no invites occurred, we never get past make_join
+        self.send_join(
+            self.remote_epa_user,
+            room_id,
+            make_join_expected_code=HTTPStatus.FORBIDDEN,
+        )
+
+    @parameterized.expand([("public", True), ("private", False)])
+    def test_local_room_remote_epa_with_invites(self, _: str, is_public: bool) -> None:
+        """
+        Test _with invites_ behavior for public and private rooms when there is an
+        incoming remote user
+        """
+        room_id = self.user_create_room(self.user_a, [], is_public=is_public)
+        assert room_id is not None, "Room should have been created"
+
+        # Test first with user 'a' who is 'pract' but is using permission of 'block all'
+        # Why this user would send an invite without granting permission first, I will
+        # never know.
+        # For a public room this should fail
+        # For a private room this will fail because lack of permissions
+        self.helper.invite(
+            room_id,
+            self.user_a,
+            self.remote_epa_user,
+            expect_code=HTTPStatus.FORBIDDEN,
+            tok=self.access_token_a,
+        )
+
+        # Place this after the invite, to prove that at least is blocked
+        if is_public:
+            self.skipTest("Can't block incoming public joins yet")
+
+        # public room should be forbidden
+        # private room should be forbidden, because invite was denied
+        self.send_join(
+            self.remote_epa_user,
+            room_id,
+            make_join_expected_code=HTTPStatus.FORBIDDEN,
+            # send_join_expected_code=HTTPStatus.FORBIDDEN,
+        )
+
+        # Try again with user "d", make a fresh room
+        room_id = self.user_create_room(self.user_d, [], is_public=is_public)
+        assert room_id is not None, "Room should have been created"
+
+        # This user is granting permission for remote_epa_user to contact them
+        self.add_permission_to_a_user(self.remote_epa_user, self.user_d)
+
+        # for a public room this should fail
+        # for a private room this should succeed(because permissions)
+        self.helper.invite(
+            room_id,
+            self.user_d,
+            self.remote_epa_user,
+            expect_code=HTTPStatus.FORBIDDEN if is_public else HTTPStatus.OK,
+            tok=self.access_token_d,
+        )
+
+        # public room should be forbidden
+        # private room should be allowed, because invite
+        self.send_join(
+            self.remote_epa_user,
+            room_id,
+            make_join_expected_code=(
+                HTTPStatus.FORBIDDEN if is_public else HTTPStatus.OK
+            ),
+        )
+
+    @parameterized.expand([("public", True), ("private", False)])
+    def test_local_room_remote_pro_no_invites(self, _: str, is_public: bool) -> None:
+        """
+        Test with no invites behavior for public and private rooms when there is an
+        incoming remote user
+        """
+        if is_public:
+            self.skipTest("Can't block incoming public joins yet")
+
+        room_id = self.user_create_room(self.user_a, [], is_public=is_public)
+        assert room_id is not None, "Room should have been created"
+
+        # public should not succeed
+        # private should also not succeed
+        # Since no invites occurred, we never get past make_join
+        self.send_join(
+            self.remote_hba_user,
+            room_id,
+            make_join_expected_code=HTTPStatus.FORBIDDEN,
+        )
+
+    @parameterized.expand([("public", True), ("private", False)])
+    def test_local_room_remote_pro_with_invites_pract_visibility(
+        self, _: str, is_public: bool
+    ) -> None:
+        """
+        Test with invites behavior for public and private rooms when there is an
+        incoming remote user
+        """
+        # The invite result on this test appears to fail its check, as public invites
+        # are not forbidden yet even between two 'pract' visible users
+        if is_public:
+            self.skipTest("Can't block incoming public joins yet")
+
+        room_id = self.user_create_room(self.user_a, [], is_public=is_public)
+        assert room_id is not None, "Room should have been created"
+
+        # Private rooms, this should be allowed without permission
+        # Public rooms, should be denied because public room
+        # Note: both users are 'pract'
+        # TODO: try with a user that is not 'pract' and not visible
+        self.helper.invite(
+            room_id,
+            self.user_a,
+            self.remote_hba_user,
+            expect_code=HTTPStatus.FORBIDDEN if is_public else HTTPStatus.OK,
+            tok=self.access_token_a,
+        )
+
+        # make_join should always succeed, as the invite will not be blocked
+        # send_join should only succeed for private rooms
+        self.send_join(
+            self.remote_hba_user,
+            room_id,
+            make_join_expected_code=HTTPStatus.OK,
+            send_join_expected_code=(
+                HTTPStatus.FORBIDDEN if is_public else HTTPStatus.OK
+            ),
+        )
+
+    @parameterized.expand([("public", True), ("private", False)])
+    def test_local_room_remote_pro_with_invites_no_permission(
+        self, _: str, is_public: bool
+    ) -> None:
+        """
+        Test with invites behavior for public and private rooms when there is an
+        incoming remote user and local user has no visibility
+        """
+        room_id = self.user_create_room(self.user_d, [], is_public=is_public)
+        assert room_id is not None, "Room should have been created"
+
+        # for both private and public rooms this should succeed(both users are 'pract')
+        self.helper.invite(
+            room_id,
+            self.user_d,
+            self.remote_hba_user,
+            expect_code=HTTPStatus.FORBIDDEN,
+            tok=self.access_token_d,
+        )
+
+        # Place this after the invite, to prove that it at least is blocked
+        if is_public:
+            self.skipTest("Can't block incoming public joins yet")
+
+        # make_join should always fail, as the invite is blocked
+        # send_join should only succeed for private rooms
+        self.send_join(
+            self.remote_hba_user,
+            room_id,
+            make_join_expected_code=HTTPStatus.FORBIDDEN,
+            send_join_expected_code=HTTPStatus.FORBIDDEN,
+        )
+
+
+class OutgoingRemoteJoinTestCase(FederatingModuleApiTestCase):
+    """
+    Test for behavior when joining a remote room
+    """
+
+    # server_name_for_this_server = "tim.test.gematik.de"
+    # This test case will model being an PRO server on the federation list
+    # By default we are SERVER_NAME_FROM_LIST
+
+    # Test with one other remote PRO server and one EPA server
+    remote_pro_user = f"@mxid:{DOMAIN_IN_LIST}"
+    remote_epa_user = f"@alice:{INSURANCE_DOMAIN_IN_LIST}"
+    # The default "fake" remote server name that has its server signing keys auto-injected
+    OTHER_SERVER_NAME = DOMAIN_IN_LIST
+
+    @override
+    def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
+        # Mock out the calls over federation.
+        self.fed_transport_client = Mock(spec=["send_transaction"])
+        self.fed_transport_client.send_transaction = AsyncMock(return_value={})
+
+        hs = self.setup_test_homeserver(
+            # Masquerade as a domain found on the federation list, then we can pass
+            # tests that verify that fact
+            self.server_name_for_this_server,
+            federation_transport_client=self.fed_transport_client,
+        )
+        return hs
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
+        super().prepare(reactor, clock, homeserver)
+        #  "a" is a practitioner
+        #  "b" is an organization
+        #  "c" is an 'orgPract'
+        self.user_a = self.register_user("a", "password")
+        self.access_token_a = self.login("a", "password")
+        self.user_b = self.register_user("b", "password")
+        self.access_token_b = self.login("b", "password")
+        self.user_c = self.register_user("c", "password")
+        self.access_token_c = self.login("c", "password")
+
+        # "d" is none of those types of actor and should be just a 'User'. For
+        # context, this could be a chatbot or an office manager
+        self.user_d = self.register_user("d", "password")
+        self.access_token_d = self.login("d", "password")
+
+        self.user_id_to_token = {
+            self.user_a: self.access_token_a,
+            self.user_b: self.access_token_b,
+            self.user_c: self.access_token_c,
+            self.user_d: self.access_token_d,
+        }
+
+        self.inv_checker: InviteChecker = self.hs.mockmod
+
+        # OTHER_SERVER_NAME already has it's signing key injected into our database so
+        # our server doesn't have to make that request. Add the other servers we will be
+        # using as well
+        self.map_server_name_to_signing_key.update(
+            {
+                INSURANCE_DOMAIN_IN_LIST: self.inject_servers_signing_key(
+                    INSURANCE_DOMAIN_IN_LIST
+                ),
+            },
+        )
+
+    @parameterized.expand([("public", True), ("private", False)])
+    def test_remote_room_pro_no_invites(self, _: str, is_public: bool) -> None:
+        """
+        Test that the local server can successfully block joining a remote room when
+        there are no invites
+        """
+        remote_room_id = self.create_remote_room(self.remote_pro_user, "10", is_public)
+        assert remote_room_id is not None
+
+        # Public rooms should fail.
+        # Private rooms should also fail because no invite. Should be a 403
+        self.do_remote_join(
+            remote_room_id, self.user_a, expected_code=HTTPStatus.FORBIDDEN
+        )
+
+    @parameterized.expand([("public", True), ("private", False)])
+    def test_remote_room_pro_with_invites(self, _: str, is_public: bool) -> None:
+        """
+        Test that the local server can successfully join a remote PRO server room, when
+        appropriate, if there are invites
+        """
+        if is_public:
+            self.skipTest("Cannot determine state before join yet")
+        remote_room_id = self.create_remote_room(self.remote_pro_user, "10", is_public)
+        assert remote_room_id is not None
+
+        # This should be enough to inject the "fact" we got an invite, and should
+        # allow private room joining. Both users are 'pract'
+        self.do_remote_invite(self.user_a, self.remote_pro_user, remote_room_id)
+
+        # Public rooms should fail with a 403. Private rooms should succeed, because of
+        # the invite
+        self.do_remote_join(
+            remote_room_id,
+            self.user_a,
+            expected_code=HTTPStatus.FORBIDDEN if is_public else None,
+        )
+
+    @parameterized.expand([("public", True), ("private", False)])
+    def test_remote_room_epa_no_invites(self, _: str, is_public: bool) -> None:
+        """
+        Test that the local server can successfully block a remote EPA server room when
+        there are no invites
+        """
+        remote_room_id = self.create_remote_room(self.remote_epa_user, "10", is_public)
+        assert remote_room_id is not None
+
+        # In both cases, this raises. Neither private nor public rooms are allowed.
+        # Public, because they are denied without invites, and private because the
+        # there was no invite
+        self.do_remote_join(
+            remote_room_id,
+            self.user_a,
+            expected_code=HTTPStatus.FORBIDDEN,
+        )
+
+        # Try with a different local user, one with no visibility
+        # Public rooms should fail. Private rooms should also fail because no invite
+        self.do_remote_join(
+            remote_room_id,
+            self.user_d,
+            expected_code=HTTPStatus.FORBIDDEN,
+        )
+
+    @parameterized.expand([("public", True), ("private", False)])
+    def test_remote_room_epa_with_invites_blocked(
+        self, _: str, is_public: bool
+    ) -> None:
+        """
+        Test that the local server can successfully block a remote EPA server room, when
+        an invite is blocked from lack of permissions
+        """
+        if is_public:
+            self.skipTest("Cannot determine state before join yet")
+
+        remote_room_id = self.create_remote_room(self.remote_epa_user, "10", is_public)
+        assert remote_room_id is not None
+
+        # Use user 'a' first
+
+        # This should be enough to inject the "fact" we got an invite, and should
+        # allow private room joining. However, user "a" has 'block all' permissions so
+        # the invite should always fail
+        self.do_remote_invite(
+            self.user_a,
+            self.remote_epa_user,
+            remote_room_id,
+            expect_code=HTTPStatus.FORBIDDEN,
+        )
+
+        # In both cases, this raises. Neither private nor public rooms are allowed.
+        # Public, because they are denied without invites, and private because the
+        # invite failed above
+        self.do_remote_join(
+            remote_room_id,
+            self.user_a,
+            expected_code=HTTPStatus.FORBIDDEN,
+        )
+
+        # Re-using this room exposed a flaw. The FakeRoom thinks that the last event
+        # in the room is the invite for 'a'. Our local copy of the room denied that
+        # event, so it doesn't exist. The next invite to occur just below will have that
+        # denied invite as it's prev_event, which will then deny that next invite(since
+        # the event doesn't exist as far as the local room is concerned). In theory,
+        # this is bad. In practice, I don't think it will happen unless a public room
+        # experiences an invite that is denied over federation(which is also not allowed).
+        # Just create a new fake room to test with instead.
+
+    @parameterized.expand([("public", True), ("private", False)])
+    def test_remote_room_epa_with_invites_allowed(
+        self, _: str, is_public: bool
+    ) -> None:
+        """
+        Test that the local server can successfully join a remote EPA server room, when
+        an invite is allowed
+        """
+        if is_public:
+            self.skipTest("Cannot determine state before join yet")
+
+        remote_room_id = self.create_remote_room(self.remote_epa_user, "10", is_public)
+        assert remote_room_id is not None
+
+        # User 'd' must grant their permission
+        self.add_permission_to_a_user(self.remote_epa_user, self.user_d)
+
+        # This should be enough to inject the "fact" we got an invite, and should
+        # allow private room joining.
+        self.do_remote_invite(
+            self.user_d,
+            self.remote_epa_user,
+            remote_room_id,
+            expect_code=HTTPStatus.OK,
+        )
+
+        # Public rooms should fail. Private rooms should succeed, but only because of
+        # the invite
+        self.do_remote_join(
+            remote_room_id,
+            self.user_d,
+            expected_code=HTTPStatus.FORBIDDEN if is_public else None,
+        )

--- a/tests/test_utils/fake_room_creation.py
+++ b/tests/test_utils/fake_room_creation.py
@@ -1,0 +1,554 @@
+# Copyright (C) 2025 Famedly
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+from typing import Any
+
+from signedjson.types import SigningKey
+from synapse.api.constants import (
+    EventTypes,
+    GuestAccess,
+    HistoryVisibility,
+    JoinRules,
+    Membership,
+    RoomCreationPreset,
+)
+from synapse.api.room_versions import KNOWN_ROOM_VERSIONS, RoomVersion
+from synapse.config.homeserver import HomeServerConfig
+from synapse.crypto.event_signing import add_hashes_and_signatures
+from synapse.events import EventBase, make_event_from_dict
+from synapse.federation.federation_client import SendJoinResult
+from synapse.types import RoomID
+from synapse.util import Clock, stringutils
+
+
+class FakeRoom:
+    """
+    This creates enough of a room to allow a remote join to complete processing
+    """
+
+    room_version: RoomVersion
+    room_id: RoomID
+    creator_id: str
+    depth_counter: int
+    auth_events_list: list[EventBase]
+    # This is almost the same as forward extremities
+    current_prev_events_id_list: list[str]
+    # does not include membership events, separate mapping
+    map_of_state_events_by_type: dict[EventTypes, EventBase]
+    # membership events
+    map_of_membership_by_mxid: dict[str, EventBase]
+
+    def __init__(
+        self,
+        hs_config: HomeServerConfig,
+        clock: Clock,
+        creator: str,
+        other_server_name: str,
+        other_server_signing_key: SigningKey,
+        room_ver: str | None = None,
+        room_preset: str = RoomCreationPreset.PUBLIC_CHAT,
+        join_rule_override: str | None = None,
+        history_visibility_override: str | None = None,
+        guest_access_override: str | None = None,
+    ) -> None:
+        self.creator_id = creator
+        self.clock = clock
+        self.server_name_this_room_is_on = other_server_name
+        self.signing_key = other_server_signing_key
+        self.depth_counter = 0
+        # generate a room id
+        random_string = stringutils.random_string(18)
+        self.room_id = RoomID(random_string, other_server_name)
+
+        if room_ver is None:
+            room_ver = hs_config.server.default_room_version.identifier
+
+        self.room_version = KNOWN_ROOM_VERSIONS.get(room_ver)
+        # TODO: factor this out into a function that can construct it instead
+        self.auth_events_list = []
+        self.current_prev_events_id_list = []
+        self.map_of_state_events_by_type = {}
+        self.map_of_membership_by_mxid = {}
+
+        # sort out the preset or the overrides
+        assert room_preset in [
+            RoomCreationPreset.PUBLIC_CHAT,
+            RoomCreationPreset.PRIVATE_CHAT,
+            RoomCreationPreset.TRUSTED_PRIVATE_CHAT,
+        ], f"An unknown room creation preset was provided: {room_preset}"
+        if room_preset == RoomCreationPreset.PUBLIC_CHAT:
+            _join_rule = JoinRules.PUBLIC
+            _his_vis = HistoryVisibility.SHARED
+            _guest_access = GuestAccess.FORBIDDEN
+        elif room_preset == RoomCreationPreset.PRIVATE_CHAT:
+            _join_rule = JoinRules.INVITE
+            _his_vis = HistoryVisibility.SHARED
+            _guest_access = GuestAccess.CAN_JOIN
+        elif room_preset == RoomCreationPreset.TRUSTED_PRIVATE_CHAT:
+            _join_rule = JoinRules.INVITE
+            _his_vis = HistoryVisibility.SHARED
+            _guest_access = GuestAccess.CAN_JOIN
+        else:
+            raise ValueError("'room_preset' was an unknown value")
+
+        join_rule = join_rule_override or _join_rule
+        history_visibiltity = history_visibility_override or _his_vis
+        guest_access = guest_access_override or _guest_access
+
+        # Build the room
+        _create_event = self.create_event()
+        _creator_member_event = self.creator_member_event()
+        _power_levels_event = self.initial_power_levels_event()
+        _join_rules_event = self.initial_join_rules_event(join_rule)
+        _history_visibility_event = self.initial_history_visibility_event(
+            history_visibiltity
+        )
+        _guest_access_event = self.initial_guest_access_event(guest_access)
+        # TODO: sort out what other state bits should add
+
+    def create_send_invite_request(
+        self,
+        sender_user_id: str,
+        target_user_id: str,
+    ) -> tuple[dict[str, Any], str]:
+        """
+        Create invite signed by the remote server. This will be the content of an
+        invite request. This is like a template, but is not added to the state of the
+        room until it is returned after being submitted to our test server(see
+        `update_member_state`)
+
+        Returns:
+            tuple of the pdu json and the event ID of that pdu
+        """
+        # as a member event, this needs the basic set of auth, plus join_rules
+        auth_events = [e.event_id for e in self.auth_events_list]
+        auth_events.append(
+            self.map_of_state_events_by_type[EventTypes.JoinRules].event_id
+        )
+
+        event = self._member_event(
+            target_user_id,
+            Membership.INVITE,
+            sender_user_id,
+            auth_events=auth_events,
+            prev_events=self.current_prev_events_id_list,
+        )
+        # Save this to the state of the room. Rather it is denied or not by the real
+        # server, it is still part of the room to be accounted for. After it is processed
+        # by the real server, it should be updated. If it is denied, the room will be
+        # always be broken from the standpoint of the real server since at some point
+        # the prev_event will resolve back to this
+        self.map_of_membership_by_mxid[event.state_key] = event
+        self.current_prev_events_id_list = [event.event_id]
+        self.depth_counter += 1
+        return event.get_pdu_json(self.clock.time_msec()), event.event_id
+
+    def promote_member_invite(
+        self,
+        signed_pdu: dict[str, Any],
+    ) -> EventBase:
+        """
+        This membership event is already part of the room "state", but it needs its
+        signatures updated to include the receiving server
+        """
+        event = make_event_from_dict(
+            signed_pdu,
+            room_version=self.room_version,
+        )
+
+        # Update the state of the room, but do not increment depth. It's not a new
+        # event, just one that got signed and returned
+        self.map_of_membership_by_mxid[event.state_key] = event
+        # self.current_prev_events_id_list = [event.event_id]
+
+        return event
+
+    def create_make_join_response(
+        self,
+        user_id: str,
+    ) -> tuple[str, EventBase, RoomVersion]:
+        """
+        A helper to construct the response for FederationClient.make_membership_event()
+        Args:
+            user_id:
+
+        Returns: tuple of [origin_server_domain, join event, RoomVersion]
+
+        """
+        # as a member event, this needs the basic set of auth, plus join_rules
+        auth_events = [e.event_id for e in self.auth_events_list]
+        auth_events.append(
+            self.map_of_state_events_by_type[EventTypes.JoinRules].event_id
+        )
+        # if there was an invite, we'll find it in the membership state
+        if user_id in self.map_of_membership_by_mxid:
+            invite_event = self.map_of_membership_by_mxid[user_id]
+            auth_events.append(invite_event.event_id)
+
+        event = self._member_event(
+            user_id,
+            Membership.JOIN,
+            user_id,
+            auth_events=auth_events,
+            prev_events=self.current_prev_events_id_list,
+        )
+        return self.room_id.domain, event, self.room_version
+
+    def create_send_join_response(
+        self,
+        user_id: str,
+        pdu: dict[str, Any],
+    ) -> SendJoinResult:
+        add_hashes_and_signatures(
+            self.room_version,
+            pdu,
+            self.server_name_this_room_is_on,
+            self.signing_key,
+        )
+
+        event = make_event_from_dict(
+            pdu,
+            room_version=self.room_version,
+        )
+
+        # The state and auth_chain need to both represent state *before* and not *after*
+        # the join itself
+        # as a member event, this needs the basic set of auth, plus join_rules
+        auth_chain = self.auth_events_list.copy()
+        auth_chain.append(self.map_of_state_events_by_type[EventTypes.JoinRules])
+        # if there was an invite, we'll find it in the members state
+        if user_id in self.map_of_membership_by_mxid:
+            invite_event = self.map_of_membership_by_mxid[user_id]
+            auth_chain.append(invite_event)
+
+        state = list(self.map_of_state_events_by_type.values())
+        state.extend(self.map_of_membership_by_mxid.values())
+
+        # This join is almost complete. Be sure to insert the new event into the current
+        # room state before sending it back
+        self.map_of_membership_by_mxid[user_id] = event
+
+        return SendJoinResult(
+            event,
+            self.room_id.domain,
+            state=state,
+            auth_chain=auth_chain,
+            partial_state=False,
+            servers_in_room=frozenset(),
+        )
+
+    def create_event(self) -> EventBase:
+        """
+        The fake creation event for this room. Adds itself to the state map and becomes
+        the first 'prev_event'
+        """
+        pdu = {
+            "room_id": self.room_id.to_string(),
+            "depth": self.depth_counter,
+            "type": "m.room.create",
+            "state_key": "",
+            "sender": self.creator_id,
+            "content": {
+                "creator": self.creator_id,
+                "m.federate": True,
+                "room_version": self.room_version.identifier,
+            },
+            "auth_events": [],
+            "prev_events": [],
+            "origin_server_ts": self.clock.time_msec(),
+        }
+        add_hashes_and_signatures(
+            self.room_version,
+            pdu,
+            self.server_name_this_room_is_on,
+            self.signing_key,
+        )
+
+        event = make_event_from_dict(
+            pdu,
+            room_version=self.room_version,
+        )
+        self.map_of_state_events_by_type[EventTypes.Create] = event
+        self.auth_events_list.append(event)
+        self.current_prev_events_id_list = [event.event_id]
+        self.depth_counter += 1
+
+        return event
+
+    def creator_member_event(self) -> EventBase:
+        """
+        The fake join membership event for the creator of this room. Adds itself to the
+        membership state map
+        """
+
+        auth_events = [e.event_id for e in self.auth_events_list]
+        event = self._member_event(
+            self.creator_id,
+            Membership.JOIN,
+            self.creator_id,
+            auth_events=auth_events,
+            prev_events=self.current_prev_events_id_list,
+        )
+        self.map_of_membership_by_mxid[self.creator_id] = event
+        self.current_prev_events_id_list = [event.event_id]
+        self.depth_counter += 1
+        return event
+
+    def initial_power_levels_event(self) -> EventBase:
+        """
+        The fake m.room.power_levels event for this room. Adds itself to the state map
+        """
+        auth_events = [e.event_id for e in self.auth_events_list]
+        # power_levels require the creator member event(or whoever made the event itself) in auth
+        auth_events.append(self.map_of_membership_by_mxid[self.creator_id].event_id)
+        event = self._power_levels_event(
+            self.creator_id,
+            content=default_power_level_events(self.creator_id),
+            auth_events=auth_events,
+            prev_events=self.current_prev_events_id_list,
+        )
+        self.map_of_state_events_by_type[EventTypes.PowerLevels] = event
+        self.auth_events_list.append(event)
+        self.current_prev_events_id_list = [event.event_id]
+        self.depth_counter += 1
+        return event
+
+    def initial_join_rules_event(self, join_rule: str) -> EventBase:
+        auth_events = [e.event_id for e in self.auth_events_list]
+        auth_events.append(self.map_of_membership_by_mxid[self.creator_id].event_id)
+
+        event = self._join_rules_event(
+            self.creator_id,
+            join_rule,
+            auth_events=auth_events,
+            prev_events=self.current_prev_events_id_list,
+        )
+        self.map_of_state_events_by_type[EventTypes.JoinRules] = event
+        self.current_prev_events_id_list = [event.event_id]
+        self.depth_counter += 1
+        return event
+
+    def initial_history_visibility_event(self, history_visibility: str) -> EventBase:
+        auth_events = [e.event_id for e in self.auth_events_list]
+        auth_events.append(self.map_of_membership_by_mxid[self.creator_id].event_id)
+
+        event = self._history_visibility_event(
+            self.creator_id,
+            history_visibility=history_visibility,
+            auth_events=auth_events,
+            prev_events=self.current_prev_events_id_list,
+        )
+        self.map_of_state_events_by_type[EventTypes.RoomHistoryVisibility] = event
+        self.current_prev_events_id_list = [event.event_id]
+        self.depth_counter += 1
+        return event
+
+    def initial_guest_access_event(self, guest_access: str) -> EventBase:
+        auth_events = [e.event_id for e in self.auth_events_list]
+        auth_events.append(self.map_of_membership_by_mxid[self.creator_id].event_id)
+
+        event = self._guest_access_event(
+            self.creator_id,
+            guest_access=guest_access,
+            auth_events=auth_events,
+            prev_events=self.current_prev_events_id_list,
+        )
+        self.map_of_state_events_by_type[EventTypes.GuestAccess] = event
+        self.current_prev_events_id_list = [event.event_id]
+        self.depth_counter += 1
+        return event
+
+    # Boiler plate event construction is below
+    def _member_event(
+        self,
+        target_user_id: str,
+        membership: str,
+        sender: str | None = None,
+        additional_content: dict | None = None,
+        auth_events: list[str] | None = None,
+        prev_events: list[str] | None = None,
+    ) -> EventBase:
+        pdu = {
+            "room_id": self.room_id.to_string(),
+            "depth": self.depth_counter,
+            "type": EventTypes.Member,
+            "sender": sender,
+            "state_key": target_user_id,
+            "content": {"membership": membership, **(additional_content or {})},
+            "auth_events": auth_events or [],
+            "prev_events": prev_events or [],
+            "origin_server_ts": self.clock.time_msec(),
+        }
+        add_hashes_and_signatures(
+            self.room_version,
+            pdu,
+            self.server_name_this_room_is_on,
+            self.signing_key,
+        )
+        return make_event_from_dict(
+            pdu,
+            room_version=self.room_version,
+        )
+
+    def _power_levels_event(
+        self,
+        sender: str,
+        content: dict[str, Any],
+        auth_events: list[str] | None = None,
+        prev_events: list[str] | None = None,
+    ) -> EventBase:
+        pdu = {
+            "room_id": self.room_id.to_string(),
+            "depth": self.depth_counter,
+            "type": EventTypes.PowerLevels,
+            "sender": sender,
+            "state_key": "",
+            "content": content,
+            "auth_events": auth_events or [],
+            "prev_events": prev_events or [],
+            "origin_server_ts": self.clock.time_msec(),
+        }
+        add_hashes_and_signatures(
+            self.room_version,
+            pdu,
+            self.server_name_this_room_is_on,
+            self.signing_key,
+        )
+
+        return make_event_from_dict(
+            pdu,
+            room_version=self.room_version,
+        )
+
+    def _join_rules_event(
+        self,
+        sender: str,
+        join_rule: str,
+        auth_events: list[str] | None = None,
+        prev_events: list[str] | None = None,
+    ) -> EventBase:
+        pdu = {
+            "room_id": self.room_id.to_string(),
+            "depth": self.depth_counter,
+            "type": EventTypes.JoinRules,
+            "sender": sender,
+            "state_key": "",
+            "content": {
+                "join_rule": join_rule,
+            },
+            "auth_events": auth_events or [],
+            "prev_events": prev_events or [],
+            "origin_server_ts": self.clock.time_msec(),
+        }
+        add_hashes_and_signatures(
+            self.room_version,
+            pdu,
+            self.server_name_this_room_is_on,
+            self.signing_key,
+        )
+
+        return make_event_from_dict(
+            pdu,
+            room_version=self.room_version,
+        )
+
+    def _history_visibility_event(
+        self,
+        sender: str,
+        history_visibility: str = "invited",
+        auth_events: list[str] | None = None,
+        prev_events: list[str] | None = None,
+    ) -> EventBase:
+        pdu = {
+            "room_id": self.room_id.to_string(),
+            "depth": self.depth_counter,
+            "type": EventTypes.RoomHistoryVisibility,
+            "sender": sender,
+            "state_key": "",
+            "content": {
+                "history_visibility": history_visibility,
+            },
+            "auth_events": auth_events or [],
+            "prev_events": prev_events or [],
+            "origin_server_ts": self.clock.time_msec(),
+        }
+        add_hashes_and_signatures(
+            self.room_version,
+            pdu,
+            self.server_name_this_room_is_on,
+            self.signing_key,
+        )
+
+        return make_event_from_dict(
+            pdu,
+            room_version=self.room_version,
+        )
+
+    def _guest_access_event(
+        self,
+        sender: str,
+        guest_access: str = "can_join",
+        auth_events: list[str] | None = None,
+        prev_events: list[str] | None = None,
+    ) -> EventBase:
+        pdu = {
+            "room_id": self.room_id.to_string(),
+            "depth": self.depth_counter,
+            "type": EventTypes.GuestAccess,
+            "sender": sender,
+            "state_key": "",
+            "content": {
+                "guest_access": guest_access,
+            },
+            "auth_events": auth_events or [],
+            "prev_events": prev_events or [],
+            "origin_server_ts": self.clock.time_msec(),
+        }
+        add_hashes_and_signatures(
+            self.room_version,
+            pdu,
+            self.server_name_this_room_is_on,
+            self.signing_key,
+        )
+
+        return make_event_from_dict(
+            pdu,
+            room_version=self.room_version,
+        )
+
+
+def default_power_level_events(creator_id: str) -> dict[str, Any]:
+    power_level_content = {
+        "users": {creator_id: 100},
+        "users_default": 0,
+        "events": {
+            EventTypes.Name: 50,
+            EventTypes.PowerLevels: 100,
+            EventTypes.RoomHistoryVisibility: 100,
+            EventTypes.CanonicalAlias: 50,
+            EventTypes.RoomAvatar: 50,
+            EventTypes.Tombstone: 100,
+            EventTypes.ServerACL: 100,
+            EventTypes.RoomEncryption: 100,
+        },
+        "events_default": 0,
+        "state_default": 50,
+        "ban": 50,
+        "kick": 50,
+        "redact": 50,
+        # For our purposes, the only diff between public and private is that invite is 0 instead of 50
+        "invite": 0,
+        "historical": 100,
+    }
+    return power_level_content


### PR DESCRIPTION
part of famedly/product-management#2826
Requires #55 

Public rooms do not require invites to join, unlike private rooms. Take advantage of this to block joining a room not on the local server if an invite does not exist

Prohibiting a join when there is an invite will be a separate pull request