### PR TITLE
Refactor and test cleanup

### DIFF
--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -174,7 +174,7 @@ class InsuredOnlyRoomScanTaskTestCase(FederatingModuleApiTestCase):
         Test that a room is deleted when a single EPA user and a single PRO user are in
         a room, but the PRO user leaves
         """
-        self.add_a_contact_to_user_by_token(self.remote_pro_user, self.access_token_d)
+        self.add_permission_to_a_user(self.remote_pro_user, self.user_d)
 
         # Make a room and invite the doctor
         room_id = self.user_d_create_room([self.remote_pro_user], is_public=False)
@@ -255,7 +255,7 @@ class InsuredOnlyRoomScanTaskTestCase(FederatingModuleApiTestCase):
         room, so it's dangling and won't be cleaned up unless `forget_room_on_leave` is
         turned on. I'm not sure I need to test for this?
         """
-        self.add_a_contact_to_user_by_token(self.remote_pro_user, self.access_token_d)
+        self.add_permission_to_a_user(self.remote_pro_user, self.user_d)
 
         # Make a room and invite the doctor
         room_id = self.user_d_create_room([self.remote_pro_user], is_public=False)
@@ -324,7 +324,7 @@ class InsuredOnlyRoomScanTaskTestCase(FederatingModuleApiTestCase):
         """
         Test that a room is not deleted until the last PRO user leaves a room
         """
-        self.add_a_contact_to_user_by_token(self.remote_pro_user, self.access_token_d)
+        self.add_permission_to_a_user(self.remote_pro_user, self.user_d)
 
         # Make a room and invite the doctor
         room_id = self.user_d_create_room([self.remote_pro_user], is_public=False)

--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -38,10 +38,13 @@ if TYPE_CHECKING:
 
 TV = TypeVar("TV")
 
+# Only use this server name for our PRO test instance
 SERVER_NAME_FROM_LIST = "tim.test.gematik.de"
 # Use a domain found in our raw fedlist data instead of inserting a fake one
 DOMAIN_IN_LIST = "timo.staging.famedly.de"
-# Also borrow an 'isInsurance' domain for testing remotes
+DOMAIN2_IN_LIST = "tim-alpha.staging.famedly.de"
+DOMAIN3_IN_LIST = "messenger.spilikin.dev"
+# Only use this server name for our EPA test instance
 INSURANCE_DOMAIN_IN_LIST = "cirosec.de"
 # And another 'isInsurance' domain for testing local
 INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL = "ti-messengertest.dev.ccs.gematik.solutions"


### PR DESCRIPTION
Some tests are showing their age. Comments were out of date or nor longer relevant, some remote users were missing. Also do some prep work to prepare for removing the Contacts API for EPA mode.