### PR TITLE
Forbid local users being invited to remote public rooms

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -718,8 +718,8 @@ class FederatingModuleApiTestCase(synapsetest.FederatingHomeserverTestCase):
         remote_room = self.remote_rooms[room_id]
         # We use the fake room to generate the invite event, which signs it with the
         # remote server signing key
-        invite_pdu, invite_event_id = remote_room.create_send_invite_request(
-            source_user_id, target_user_id
+        invite_pdu, room_initial_state, invite_event_id = (
+            remote_room.create_send_invite_request(source_user_id, target_user_id)
         )
         remote_server_domain = UserID.from_string(source_user_id).domain
 
@@ -730,7 +730,7 @@ class FederatingModuleApiTestCase(synapsetest.FederatingHomeserverTestCase):
             f"/_matrix/federation/v2/invite/{room_id}/{invite_event_id}",
             content={
                 "event": invite_pdu,
-                "invite_room_state": [],
+                "invite_room_state": room_initial_state,
                 "room_version": remote_room.room_version.identifier,
             },
             from_server=remote_server_domain,

--- a/tests/test_remote_joins.py
+++ b/tests/test_remote_joins.py
@@ -370,8 +370,6 @@ class OutgoingRemoteJoinTestCase(FederatingModuleApiTestCase):
         Test that the local server can successfully join a remote PRO server room, when
         appropriate, if there are invites
         """
-        if is_public:
-            self.skipTest("Cannot determine state before join yet")
         remote_room_id = self.create_remote_room(self.remote_pro_user, "10", is_public)
         assert remote_room_id is not None
 
@@ -421,9 +419,6 @@ class OutgoingRemoteJoinTestCase(FederatingModuleApiTestCase):
         Test that the local server can successfully block a remote EPA server room, when
         an invite is blocked from lack of permissions
         """
-        if is_public:
-            self.skipTest("Cannot determine state before join yet")
-
         remote_room_id = self.create_remote_room(self.remote_epa_user, "10", is_public)
         assert remote_room_id is not None
 
@@ -465,9 +460,6 @@ class OutgoingRemoteJoinTestCase(FederatingModuleApiTestCase):
         Test that the local server can successfully join a remote EPA server room, when
         an invite is allowed
         """
-        if is_public:
-            self.skipTest("Cannot determine state before join yet")
-
         remote_room_id = self.create_remote_room(self.remote_epa_user, "10", is_public)
         assert remote_room_id is not None
 


### PR DESCRIPTION
Invites from remote servers usually have some stripped state events added to the request. Parse that data to see if the room being invited to is public, and deny if so

Requires: #58 