### PR TITLE
feat: Forbid public room federation by forcing `m.federate` to False

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ modules:
         inactive_room_scan:
           enabled: true or false # optional switch to disable the room scan for inactive rooms, defaults to true
           grace_period: see 'Duration Parsing' below # Length of time a room is allowed to have no message activity before it is eligible for deletion. Ignored if 'enabled' is false. Defaults to "26w" which is 6 months
+        override_public_room_federation: true or false, # Forces the `m.federate` flag to be set to False when creating a public room to prevent it from federating. Default is "true", disable with "false"
 ```
 ### Duration Parsing
 Settings labeled as 'duration_parsing' allow for a string representation of the value

--- a/synapse_invite_checker/config.py
+++ b/synapse_invite_checker/config.py
@@ -47,3 +47,4 @@ class InviteCheckerConfig:
     inactive_room_scan_options: InactiveRoomScanConfig = field(
         default_factory=InactiveRoomScanConfig
     )
+    override_public_room_federation: bool = True


### PR DESCRIPTION
Always disable federation with local public rooms by setting `m.federate` to `False` when creating a room. This will override what is set by any client requests.

Provides for a configuration setting to disable.
`override_public_room_federation`: "false" will stop overriding the event, default is "true"

Resolves: famedly/product-management#2926
Resolves: famedly/product-management#2948