### PR TITLE
chore: Only kick insured users from their rooms, do not purge

### DIFF
--- a/tests/unittest.py
+++ b/tests/unittest.py
@@ -803,7 +803,7 @@ class HomeserverTestCase(TestCase):
         if soft_failed:
             event.internal_metadata.soft_failed = True
 
-        self.get_success(
+        self.get_success_or_raise(
             event_creator.handle_new_client_event(
                 requester, events_and_context=[(event, context)]
             )


### PR DESCRIPTION
Resolves: famedly/product-management#2947

Instead of just outright purging an EPA server room, 'block' then 'leave' the room with local users. By blocking the room, no further activity should be possible but will allow leaves to still take place

Apparently, server notices rooms were being included in the room scan before. They are now excluded from the EPA room scan but will still be included for inactive purging