### PR TITLE
chore: Forbid changing room state event on EPA server

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ modules:
           enabled: true or false # optional switch to disable the room scan for inactive rooms, defaults to true
           grace_period: see 'Duration Parsing' below # Length of time a room is allowed to have no message activity before it is eligible for deletion. Ignored if 'enabled' is false. Defaults to "26w" which is 6 months
         override_public_room_federation: true or false, # Forces the `m.federate` flag to be set to False when creating a public room to prevent it from federating. Default is "true", disable with "false"
+        prohibit_world_readable_rooms: true or false, # Prevent setting any rooms history visibility as 'world_readable'. Defaults to "true"
 ```
 
 ### Duration Parsing

--- a/synapse_invite_checker/config.py
+++ b/synapse_invite_checker/config.py
@@ -47,3 +47,4 @@ class InviteCheckerConfig:
         default_factory=InactiveRoomScanConfig
     )
     override_public_room_federation: bool = True
+    prohibit_world_readable_rooms: bool = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -179,3 +179,29 @@ class ConfigParsingTestCase(TestCase):
         test_config = self.config.copy()
         test_config.update({"override_public_room_federation": "nope"})
         self.assertRaises(ConfigError, InviteChecker.parse_config, test_config)
+
+    def test_prohibit_world_readable_rooms_override_defaults_to_true(self) -> None:
+        test_config = self.config.copy()
+        config = InviteChecker.parse_config(test_config)
+        assert (
+            config.prohibit_world_readable_rooms
+        ), "`prohibit_world_readable_rooms` should default to 'True'"
+
+    def test_prohibit_world_readable_rooms_override_can_be_disabled(self) -> None:
+        test_config = self.config.copy()
+        test_config.update({"prohibit_world_readable_rooms": False})
+        config = InviteChecker.parse_config(test_config)
+        assert (
+            config.prohibit_world_readable_rooms is False
+        ), "`prohibit_world_readable_rooms` should be `False`'"
+
+    def test_prohibit_world_readable_rooms_override_raises(self) -> None:
+        test_config = self.config.copy()
+        # Although a boolean is an int, and int is not a boolean
+        test_config.update({"prohibit_world_readable_rooms": "1"})
+        self.assertRaises(ConfigError, InviteChecker.parse_config, test_config)
+
+        # No silly strings. Shame, really....
+        test_config = self.config.copy()
+        test_config.update({"prohibit_world_readable_rooms": "hi_mom!"})
+        self.assertRaises(ConfigError, InviteChecker.parse_config, test_config)

--- a/tests/test_utils/fake_room_creation.py
+++ b/tests/test_utils/fake_room_creation.py
@@ -102,7 +102,7 @@ class FakeRoom:
             raise ValueError("'room_preset' was an unknown value")
 
         join_rule = join_rule_override or _join_rule
-        history_visibiltity = history_visibility_override or _his_vis
+        history_visibility = history_visibility_override or _his_vis
         guest_access = guest_access_override or _guest_access
 
         # Build the room
@@ -111,7 +111,7 @@ class FakeRoom:
         _power_levels_event = self.initial_power_levels_event()
         _join_rules_event = self.initial_join_rules_event(join_rule)
         _history_visibility_event = self.initial_history_visibility_event(
-            history_visibiltity
+            history_visibility
         )
         _guest_access_event = self.initial_guest_access_event(guest_access)
         # TODO: sort out what other state bits should add


### PR DESCRIPTION
Resolves famedly/product-management#2941

Now it is forbidden to change the room's 
* `m.room.join_rules` to "public" 
* `m.room.history_visibility` to "world_readable"

Folded some previous changes that were looking at `initial_state` during room creation into this so it was no duplicated.

Rolled the prevention of changing `m.room.history_visibility` during room creation into this as well, I think it got skipped before somehow

New configuration setting:
```
prohibit_world_readable_rooms: "true" or "false"  # Defaults to "true", use "false" to disable checking for this
```