### PR TITLE
chore: Allow to disable the DM check for invites

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ modules:
           grace_period: see 'Duration Parsing' below # Length of time a room is allowed to have no message activity before it is eligible for deletion. Ignored if 'enabled' is false. Defaults to "26w" which is 6 months
         override_public_room_federation: true or false, # Forces the `m.federate` flag to be set to False when creating a public room to prevent it from federating. Default is "true", disable with "false"
         prohibit_world_readable_rooms: true or false, # Prevent setting any rooms history visibility as 'world_readable'. Defaults to "true"
+        block_invites_into_dms: true or false, # Prevent invites into existing DM chats. Defaults to true
 ```
 
 ### Duration Parsing

--- a/synapse_invite_checker/config.py
+++ b/synapse_invite_checker/config.py
@@ -48,3 +48,4 @@ class InviteCheckerConfig:
     )
     override_public_room_federation: bool = True
     prohibit_world_readable_rooms: bool = True
+    block_invites_into_dms: bool = True

--- a/synapse_invite_checker/invite_checker.py
+++ b/synapse_invite_checker/invite_checker.py
@@ -365,6 +365,11 @@ class InviteChecker:
             msg = "`prohibit_world_readable_rooms` must be a boolean"
             raise ConfigError(msg)
         _config.prohibit_world_readable_rooms = _prohibit_world_readable_rooms
+
+        _block_invites_into_dms = config.get(
+            "block_invites_into_dms", _config.block_invites_into_dms
+        )
+        _config.block_invites_into_dms = _block_invites_into_dms
         return _config
 
     def after_startup(self) -> None:
@@ -670,7 +675,7 @@ class InviteChecker:
         # tests in the Testsuite. In the context of calling this directly from
         # `on_create_room()` above, there may not be a room_id yet.
         if self.api.is_mine(inviter):
-            if room_id:
+            if room_id and self.config.block_invites_into_dms:
                 direct = await self.api.account_data_manager.get_global(
                     inviter, AccountDataTypes.DIRECT
                 )


### PR DESCRIPTION
Resolves: famedly/product-management#2990

Adds configuration option to disable the DM check
```
block_invites_into_dms: true or false # defaults to "true"
```