### PR TITLE
chore: Test permissions a little more robustly

### DIFF
--- a/tests/test_createrooms_local.py
+++ b/tests/test_createrooms_local.py
@@ -44,6 +44,14 @@ class LocalProModeCreateRoomTest(FederatingModuleApiTestCase):
 
     def default_config(self) -> dict[str, Any]:
         conf = super().default_config()
+        assert "modules" in conf, "modules missing from config dict during construction"
+
+        # There should only be a single item in the 'modules' list, since this tests that module
+        assert len(conf["modules"]) == 1, "more than one module found in config"
+
+        conf["modules"][0].setdefault("config", {}).update(
+            {"default_permissions": {"defaultSetting": "allow all"}}
+        )
         conf["server_notices"] = {"system_mxid_localpart": "server", "auto_join": True}
         return conf
 
@@ -191,6 +199,9 @@ class LocalEpaModeCreateRoomTest(FederatingModuleApiTestCase):
         assert len(conf["modules"]) == 1, "more than one module found in config"
 
         conf["modules"][0].setdefault("config", {}).update({"tim-type": "epa"})
+        conf["modules"][0].setdefault("config", {}).update(
+            {"default_permissions": {"defaultSetting": "allow all"}}
+        )
         conf["server_notices"] = {"system_mxid_localpart": "server", "auto_join": True}
         return conf
 

--- a/tests/test_local_invites.py
+++ b/tests/test_local_invites.py
@@ -12,12 +12,15 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
+from http import HTTPStatus
 from typing import Any
 
+from parameterized import parameterized
 from synapse.server import HomeServer
 from synapse.util import Clock
 from twisted.internet.testing import MemoryReactor
 
+from synapse_invite_checker.types import PermissionConfig, PermissionDefaultSetting
 from tests.base import FederatingModuleApiTestCase
 from tests.test_utils import INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL
 
@@ -31,10 +34,218 @@ class LocalProModeInviteTest(FederatingModuleApiTestCase):
     def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
         super().prepare(reactor, clock, homeserver)
         self.user_a = self.register_user("a", "password")
-        self.access_token = self.login("a", "password")
         self.user_b = self.register_user("b", "password")
         self.user_c = self.register_user("c", "password")
         self.user_d = self.register_user("d", "password")
+
+        self.access_token = self.login("a", "password")
+        self.login("b", "password")
+        self.login("c", "password")
+        self.login("d", "password")
+
+    @parameterized.expand(
+        [
+            (
+                "allow_all_public",
+                PermissionDefaultSetting.ALLOW_ALL,
+                True,
+                HTTPStatus.OK,
+            ),
+            (
+                "allow_all_private",
+                PermissionDefaultSetting.ALLOW_ALL,
+                False,
+                HTTPStatus.OK,
+            ),
+            (
+                "block_all_public",
+                PermissionDefaultSetting.BLOCK_ALL,
+                True,
+                HTTPStatus.FORBIDDEN,
+            ),
+            (
+                "block_all_private",
+                PermissionDefaultSetting.BLOCK_ALL,
+                False,
+                HTTPStatus.FORBIDDEN,
+            ),
+        ]
+    )
+    def test_global_permissions(
+        self,
+        label: str,
+        default_setting: PermissionDefaultSetting,
+        is_public: bool,
+        expected_result: int,
+    ) -> None:
+        room_id = self.create_local_room(
+            self.user_b,
+            [],
+            is_public=is_public,
+        )
+        assert room_id is not None, "Room should have been created"
+
+        # Set the perms
+        self.set_permissions_for_user(
+            self.user_a,
+            PermissionConfig(defaultSetting=default_setting),
+        )
+
+        # invite the test user to the other users room
+        self.helper.invite(
+            room_id,
+            self.user_b,
+            self.user_a,
+            expect_code=expected_result,
+            tok=self.map_user_id_to_token[self.user_b],
+        )
+
+    @parameterized.expand(
+        [
+            (
+                "allow_all_public",
+                PermissionDefaultSetting.ALLOW_ALL,
+                True,
+                HTTPStatus.FORBIDDEN,
+            ),
+            (
+                "allow_all_private",
+                PermissionDefaultSetting.ALLOW_ALL,
+                False,
+                HTTPStatus.FORBIDDEN,
+            ),
+            (
+                "block_all_public",
+                PermissionDefaultSetting.BLOCK_ALL,
+                True,
+                HTTPStatus.OK,
+            ),
+            (
+                "block_all_private",
+                PermissionDefaultSetting.BLOCK_ALL,
+                False,
+                HTTPStatus.OK,
+            ),
+        ]
+    )
+    def test_server_exceptions(
+        self,
+        label: str,
+        default_setting: PermissionDefaultSetting,
+        is_public: bool,
+        expected_result: int,
+    ) -> None:
+        room_id = self.create_local_room(
+            self.user_b,
+            [],
+            is_public=is_public,
+        )
+        assert room_id is not None, "Room should have been created"
+
+        # Set the perms
+        self.set_permissions_for_user(
+            self.user_a,
+            PermissionConfig(
+                defaultSetting=default_setting,
+                serverExceptions={self.server_name_for_this_server: {}},
+            ),
+        )
+
+        # invite the test user to the other users room
+        self.helper.invite(
+            room_id,
+            self.user_b,
+            self.user_a,
+            expect_code=expected_result,
+            tok=self.map_user_id_to_token[self.user_b],
+        )
+
+    @parameterized.expand(
+        [
+            (
+                "allow_all_public",  # just a label for test output, ignore
+                PermissionDefaultSetting.ALLOW_ALL,  # the global default
+                True,  # if the room is public
+                # if the expected result should succeed, we use the invert to
+                # test the opposite case on the same test run
+                # (if "b" would succeed, "c" should fail)
+                False,
+            ),
+            (
+                "allow_all_private",
+                PermissionDefaultSetting.ALLOW_ALL,
+                False,
+                False,
+            ),
+            (
+                "block_all_public",
+                PermissionDefaultSetting.BLOCK_ALL,
+                True,
+                True,
+            ),
+            (
+                "block_all_private",
+                PermissionDefaultSetting.BLOCK_ALL,
+                False,
+                True,
+            ),
+        ]
+    )
+    def test_user_exceptions(
+        self,
+        label: str,
+        default_setting: PermissionDefaultSetting,
+        is_public: bool,
+        expected_result: bool,
+    ) -> None:
+        # Our test user "a" will be invited to two different rooms, one from user "b"
+        # and one from user "c". Since we will have a global default permission that
+        # differs, and we are testing userExceptions, the results should be opposite of
+        # each other.
+        user_exceptions = {self.user_b: {}}
+
+        user_b_expectation = HTTPStatus.OK if expected_result else HTTPStatus.FORBIDDEN
+        user_c_expectation = HTTPStatus.FORBIDDEN if expected_result else HTTPStatus.OK
+        # Set the perms. By setting them before the invite takes place, it should
+        # prevent cross-contamination between other test runs
+        self.set_permissions_for_user(
+            self.user_a,
+            PermissionConfig(
+                defaultSetting=default_setting,
+                userExceptions=user_exceptions,
+            ),
+        )
+
+        room_b = self.create_local_room(
+            self.user_b,
+            [],
+            is_public=is_public,
+        )
+        assert room_b is not None, "Room should have been created"
+
+        # invite the test user to the users rooms that has permission
+        self.helper.invite(
+            room_b,
+            self.user_b,
+            self.user_a,
+            expect_code=user_b_expectation,
+            tok=self.map_user_id_to_token[self.user_b],
+        )
+        room_c = self.create_local_room(
+            self.user_c,
+            [],
+            is_public=is_public,
+        )
+        assert room_c is not None, "Room should have been created"
+
+        # invite the test user to the user room that doesn't have permissions
+        self.helper.invite(
+            room_c,
+            self.user_c,
+            self.user_a,
+            expect_code=user_c_expectation,
+            tok=self.map_user_id_to_token[self.user_c],
+        )
 
     def test_invite_to_dm(self) -> None:
         """Tests that a dm with a local user can be created, but nobody else invited"""
@@ -158,6 +369,8 @@ class LocalEpaModeInviteTest(FederatingModuleApiTestCase):
         self.user_e = self.register_user("e", "password")
         self.user_f = self.register_user("f", "password")
         self.access_token = self.login("d", "password")
+        self.login("e", "password")
+        self.login("f", "password")
 
     def default_config(self) -> dict[str, Any]:
         conf = super().default_config()
@@ -168,6 +381,159 @@ class LocalEpaModeInviteTest(FederatingModuleApiTestCase):
 
         conf["modules"][0].setdefault("config", {}).update({"tim-type": "epa"})
         return conf
+
+    @parameterized.expand(
+        [
+            (
+                "allow_all_private",
+                PermissionDefaultSetting.ALLOW_ALL,
+                HTTPStatus.FORBIDDEN,
+            ),
+            (
+                "block_all_private",
+                PermissionDefaultSetting.BLOCK_ALL,
+                HTTPStatus.FORBIDDEN,
+            ),
+        ]
+    )
+    def test_global_permissions(
+        self,
+        label: str,
+        default_setting: PermissionDefaultSetting,
+        expected_result: int,
+    ) -> None:
+        room_id = self.create_local_room(
+            self.user_e,
+            [],
+            is_public=False,
+        )
+        assert room_id is not None, "Room should have been created"
+
+        # Set the perms
+        self.set_permissions_for_user(
+            self.user_d,
+            PermissionConfig(defaultSetting=default_setting),
+        )
+
+        # invite the test user to the other users room
+        self.helper.invite(
+            room_id,
+            self.user_e,
+            self.user_d,
+            expect_code=expected_result,
+            tok=self.map_user_id_to_token[self.user_e],
+        )
+
+    @parameterized.expand(
+        [
+            (
+                "allow_all_private",
+                PermissionDefaultSetting.ALLOW_ALL,
+                HTTPStatus.FORBIDDEN,
+            ),
+            (
+                "block_all_private",
+                PermissionDefaultSetting.BLOCK_ALL,
+                HTTPStatus.FORBIDDEN,
+            ),
+        ]
+    )
+    def test_server_exceptions(
+        self,
+        label: str,
+        default_setting: PermissionDefaultSetting,
+        expected_result: int,
+    ) -> None:
+        room_id = self.create_local_room(
+            self.user_e,
+            [],
+            is_public=False,
+        )
+        assert room_id is not None, "Room should have been created"
+
+        # Set the perms
+        self.set_permissions_for_user(
+            self.user_d,
+            PermissionConfig(
+                defaultSetting=default_setting,
+                serverExceptions={self.server_name_for_this_server: {}},
+            ),
+        )
+
+        # invite the test user to the other users room
+        self.helper.invite(
+            room_id,
+            self.user_e,
+            self.user_d,
+            expect_code=expected_result,
+            tok=self.map_user_id_to_token[self.user_e],
+        )
+
+    @parameterized.expand(
+        [
+            (
+                "allow_all_private",  # just a label for test output, ignore
+                PermissionDefaultSetting.ALLOW_ALL,  # the global default
+                HTTPStatus.FORBIDDEN,  # the expected return code
+            ),
+            (
+                "block_all_private",
+                PermissionDefaultSetting.BLOCK_ALL,
+                HTTPStatus.FORBIDDEN,
+            ),
+        ]
+    )
+    def test_user_exceptions(
+        self,
+        label: str,
+        default_setting: PermissionDefaultSetting,
+        expected_result: int,
+    ) -> None:
+        # Our test user "d" will be invited to two different rooms, one from user "e"
+        # and one from user "f". For an EPA server, this shouldn't matter as any local
+        # invites are denied
+        user_exceptions = {self.user_e: {}}
+
+        # Set the perms. By setting them before the invite takes place, it should
+        # prevent cross-contamination between other test runs
+        self.set_permissions_for_user(
+            self.user_d,
+            PermissionConfig(
+                defaultSetting=default_setting,
+                userExceptions=user_exceptions,
+            ),
+        )
+
+        room_e = self.create_local_room(
+            self.user_e,
+            [],
+            is_public=False,
+        )
+        assert room_e is not None, "Room should have been created"
+
+        # invite the test user to the users rooms that has permission
+        self.helper.invite(
+            room_e,
+            self.user_e,
+            self.user_d,
+            expect_code=expected_result,
+            tok=self.map_user_id_to_token[self.user_e],
+        )
+        room_f = self.create_local_room(
+            self.user_f,
+            [],
+            is_public=False,
+        )
+        assert room_f is not None, "Room should have been created"
+
+        # invite the test user to the user room that doesn't have permissions
+        self.helper.invite(
+            room_f,
+            self.user_f,
+            self.user_d,
+            expect_code=expected_result,
+            tok=self.map_user_id_to_token[self.user_f],
+        )
 
     def test_invite_to_dm_post_room_creation(self) -> None:
         """Tests that a private room as a dm will deny inviting any local users"""

--- a/tests/test_local_joins.py
+++ b/tests/test_local_joins.py
@@ -14,17 +14,20 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 import logging
 from http import HTTPStatus
+from typing import Any
 
 from synapse.server import HomeServer
 from synapse.util import Clock
 from twisted.internet.testing import MemoryReactor
 
 from tests.base import FederatingModuleApiTestCase
+from tests.test_utils import INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL
+
 
 logger = logging.getLogger(__name__)
 
 
-class LocalJoinTestCase(FederatingModuleApiTestCase):
+class LocalProJoinTestCase(FederatingModuleApiTestCase):
     """
     Tests to verify that we don't break local public/private rooms by accident.
     Specifically, this checks the code for joining a room and not just inviting. This is
@@ -38,12 +41,21 @@ class LocalJoinTestCase(FederatingModuleApiTestCase):
         super().prepare(reactor, clock, homeserver)
         self.user_a = self.register_user("a", "password")
         self.user_b = self.register_user("b", "password")
-        self.user_c = self.register_user("c", "password")
-        self.user_d = self.register_user("d", "password")
         self.access_token_a = self.login("a", "password")
         self.access_token_b = self.login("b", "password")
-        self.access_token_c = self.login("c", "password")
-        self.access_token_d = self.login("d", "password")
+
+    def default_config(self) -> dict[str, Any]:
+        conf = super().default_config()
+        assert "modules" in conf, "modules missing from config dict during construction"
+
+        # There should only be a single item in the 'modules' list, since this tests that module
+        assert len(conf["modules"]) == 1, "more than one module found in config"
+
+        conf["modules"][0].setdefault("config", {}).update({"tim-type": "pro"})
+        conf["modules"][0].setdefault("config", {}).update(
+            {"default_permissions": {"defaultSetting": "allow all"}}
+        )
+        return conf
 
     def test_joining_public_with_invites(self) -> None:
         """Test joining a local public room with invites is allowed"""
@@ -51,12 +63,7 @@ class LocalJoinTestCase(FederatingModuleApiTestCase):
         assert room_id is not None, "Room should have been created"
 
         self.helper.invite(room_id, self.user_a, self.user_b, tok=self.access_token_a)
-        self.helper.invite(room_id, self.user_a, self.user_c, tok=self.access_token_a)
-        self.helper.invite(room_id, self.user_a, self.user_d, tok=self.access_token_a)
-
         self.helper.join(room_id, self.user_b, tok=self.access_token_b)
-        self.helper.join(room_id, self.user_c, tok=self.access_token_c)
-        self.helper.join(room_id, self.user_d, tok=self.access_token_d)
 
     def test_joining_public_no_invites(self) -> None:
         """Test joining a local public room with no invites is allowed"""
@@ -64,8 +71,6 @@ class LocalJoinTestCase(FederatingModuleApiTestCase):
         assert room_id is not None, "Room should have been created"
 
         self.helper.join(room_id, self.user_b, tok=self.access_token_b)
-        self.helper.join(room_id, self.user_c, tok=self.access_token_c)
-        self.helper.join(room_id, self.user_d, tok=self.access_token_d)
 
     def test_joining_private_no_invites(self) -> None:
         """Test joining a local private room with no invites is denied"""
@@ -78,18 +83,6 @@ class LocalJoinTestCase(FederatingModuleApiTestCase):
             expect_code=HTTPStatus.FORBIDDEN,
             tok=self.access_token_b,
         )
-        self.helper.join(
-            room_id,
-            self.user_c,
-            expect_code=HTTPStatus.FORBIDDEN,
-            tok=self.access_token_c,
-        )
-        self.helper.join(
-            room_id,
-            self.user_d,
-            expect_code=HTTPStatus.FORBIDDEN,
-            tok=self.access_token_d,
-        )
 
     def test_joining_private_with_invites(self) -> None:
         """Test joining a local private room with invites is allowed"""
@@ -97,9 +90,89 @@ class LocalJoinTestCase(FederatingModuleApiTestCase):
         assert room_id is not None, "Room should have been created"
 
         self.helper.invite(room_id, self.user_a, self.user_b, tok=self.access_token_a)
-        self.helper.invite(room_id, self.user_a, self.user_c, tok=self.access_token_a)
-        self.helper.invite(room_id, self.user_a, self.user_d, tok=self.access_token_a)
-
         self.helper.join(room_id, self.user_b, tok=self.access_token_b)
-        self.helper.join(room_id, self.user_c, tok=self.access_token_c)
-        self.helper.join(room_id, self.user_d, tok=self.access_token_d)
+
+
+class LocalEpaJoinTestCase(FederatingModuleApiTestCase):
+    """
+    Tests to verify that we don't break local public/private rooms behavior by accident.
+    Specifically, this checks the code for joining a room and not just inviting
+    """
+
+    server_name_for_this_server = INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
+        super().prepare(reactor, clock, homeserver)
+        self.user_a = self.register_user("a", "password")
+        self.user_b = self.register_user("b", "password")
+        self.access_token_a = self.login("a", "password")
+        self.access_token_b = self.login("b", "password")
+
+    def default_config(self) -> dict[str, Any]:
+        conf = super().default_config()
+        assert "modules" in conf, "modules missing from config dict during construction"
+
+        # There should only be a single item in the 'modules' list, since this tests that module
+        assert len(conf["modules"]) == 1, "more than one module found in config"
+
+        conf["modules"][0].setdefault("config", {}).update({"tim-type": "epa"})
+        conf["modules"][0].setdefault("config", {}).update(
+            {"default_permissions": {"defaultSetting": "allow all"}}
+        )
+        return conf
+
+    def test_joining_public_fails(self) -> None:
+        """
+        Test joining a local public room with or without invites fails
+
+        See comments below for thoughts on why
+        """
+        room_id = self.create_local_room(self.user_a, [], is_public=True)
+        # Public rooms don't exist, so it should be "None" here. Rather hard to invite
+        # and join a room without a room ID
+        assert room_id is None, "Room should not have been created"
+
+        # Actually you can invite to a room with no ID, but will still fail for us
+        # because invites between two EPA members is forbidden
+        self.helper.invite(
+            room_id,
+            self.user_a,
+            self.user_b,
+            expect_code=HTTPStatus.FORBIDDEN,
+            tok=self.access_token_a,
+        )
+
+        # Trying to join a room with a "None" as a room ID returns a 400(because the
+        # "room id" does not start with a "!" as it's supposed to). We don't have to
+        # test that
+
+    def test_joining_private_no_invites(self) -> None:
+        """Test joining a local private room with no invites is denied"""
+        room_id = self.create_local_room(self.user_a, [], is_public=False)
+        assert room_id is not None, "Room should have been created"
+
+        self.helper.join(
+            room_id,
+            self.user_b,
+            expect_code=HTTPStatus.FORBIDDEN,
+            tok=self.access_token_b,
+        )
+
+    def test_joining_private_with_invites(self) -> None:
+        """Test joining a local private room with invites is denied"""
+        room_id = self.create_local_room(self.user_a, [], is_public=False)
+        assert room_id is not None, "Room should have been created"
+
+        self.helper.invite(
+            room_id,
+            self.user_a,
+            self.user_b,
+            expect_code=HTTPStatus.FORBIDDEN,
+            tok=self.access_token_a,
+        )
+        self.helper.join(
+            room_id,
+            self.user_b,
+            expect_code=HTTPStatus.FORBIDDEN,
+            tok=self.access_token_b,
+        )

--- a/tests/test_remote_joins.py
+++ b/tests/test_remote_joins.py
@@ -58,6 +58,19 @@ class IncomingRemoteJoinTestCase(FederatingModuleApiTestCase):
         # using as well
         self.inject_servers_signing_key(INSURANCE_DOMAIN_IN_LIST)
 
+    def default_config(self) -> dict[str, Any]:
+        conf = super().default_config()
+        assert "modules" in conf, "modules missing from config dict during construction"
+
+        # There should only be a single item in the 'modules' list, since this tests that module
+        assert len(conf["modules"]) == 1, "more than one module found in config"
+
+        conf["modules"][0].setdefault("config", {}).update({"tim-type": "pro"})
+        conf["modules"][0].setdefault("config", {}).update(
+            {"default_permissions": {"defaultSetting": "allow all"}}
+        )
+        return conf
+
     @parameterized.expand([("public", True), ("private", False)])
     def test_local_room_remote_epa_no_invites(self, _: str, is_public: bool) -> None:
         """
@@ -125,9 +138,7 @@ class IncomingRemoteJoinTestCase(FederatingModuleApiTestCase):
         )
 
     @parameterized.expand([("public", True), ("private", False)])
-    def test_local_room_remote_pro_with_invites_pract_visibility(
-        self, _: str, is_public: bool
-    ) -> None:
+    def test_local_room_remote_pro_with_invites(self, _: str, is_public: bool) -> None:
         """
         Test with invites behavior for public and private rooms when there is an
         incoming remote user
@@ -147,33 +158,6 @@ class IncomingRemoteJoinTestCase(FederatingModuleApiTestCase):
 
         # make_join should only succeed for private rooms, and be forbidden for public
         # send_join should only succeed for private rooms
-        self.send_join(
-            self.remote_pro_user,
-            room_id,
-            make_join_expected_code=(
-                HTTPStatus.FORBIDDEN if is_public else HTTPStatus.OK
-            ),
-        )
-
-    @parameterized.expand([("public", True), ("private", False)])
-    def test_local_room_remote_pro_with_invites_no_permission(
-        self, _: str, is_public: bool
-    ) -> None:
-        """
-        Test with invites behavior for public and private rooms when inviting a remote user.
-        """
-        room_id = self.create_local_room(self.user_d, [], is_public=is_public)
-        assert room_id is not None, "Room should have been created"
-
-        # Inviting a remote user is allowed by default
-        self.helper.invite(
-            room_id,
-            self.user_d,
-            self.remote_pro_user,
-            expect_code=HTTPStatus.FORBIDDEN if is_public else HTTPStatus.OK,
-            tok=self.access_token_d,
-        )
-
         self.send_join(
             self.remote_pro_user,
             room_id,
@@ -279,6 +263,19 @@ class OutgoingRemoteJoinTestCase(FederatingModuleApiTestCase):
         # our server doesn't have to make that request. Add the other servers we will be
         # using as well
         self.inject_servers_signing_key(INSURANCE_DOMAIN_IN_LIST)
+
+    def default_config(self) -> dict[str, Any]:
+        conf = super().default_config()
+        assert "modules" in conf, "modules missing from config dict during construction"
+
+        # There should only be a single item in the 'modules' list, since this tests that module
+        assert len(conf["modules"]) == 1, "more than one module found in config"
+
+        conf["modules"][0].setdefault("config", {}).update({"tim-type": "epa"})
+        conf["modules"][0].setdefault("config", {}).update(
+            {"default_permissions": {"defaultSetting": "allow all"}}
+        )
+        return conf
 
     @parameterized.expand([("public", True), ("private", False)])
     def test_remote_room_pro_no_invites(self, _: str, is_public: bool) -> None:


### PR DESCRIPTION
Part of famedly/product-management#2956

> * Refactor permission test cases to test all variants independent of the default and structured by the current set of requirements instead of ordered by hba user vs normal user, etc. Ideally we would have a table of invitee permissions default, server and user exceptions, inviter and invitee and expected result. (We still need SOME tests for the default case of course, see https://github.com/famedly/product-management/issues/2967 )

I do not think this got completely done as expected, but there are some decent improvements here. I dislike that the line removal from #74 seems to have been for nothing

Depends on
* #74 