### PR TITLE
fix: Account for invites sent when calculating when to kick local users from an EPA room

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ modules:
         insured_only_room_scan:
           enabled: true or false  # optional switch to disable the insured-only room scan from running.  The scan is enabled by default, but only runs in EPA mode, otherwise this option is ignored and the scan is disabled.
           grace_period: see 'Duration Parsing' below, # Length of time a room with only EPA members is allowed to exist before deletion. Ignored if `enabled` is false. Defaults to "1w"
+          invite_grace_period: see 'Duration Parsing' below, # A separate grace period just for invites, to allow more time for PRO server users to respond to insured users. Ignored if `enabled` is false. Defaults to "1w"
         inactive_room_scan:
           enabled: true or false # optional switch to disable the room scan for inactive rooms, defaults to true
           grace_period: see 'Duration Parsing' below # Length of time a room is allowed to have no message activity before it is eligible for deletion. Ignored if 'enabled' is false. Defaults to "26w" which is 6 months

--- a/synapse_invite_checker/config.py
+++ b/synapse_invite_checker/config.py
@@ -21,6 +21,7 @@ from synapse_invite_checker.types import DefaultPermissionConfig, TimType
 @dataclass
 class InsuredOnlyRoomScanConfig:
     grace_period_ms: int = 0
+    invite_grace_period_ms: int = 0
     enabled: bool = False
 
 

--- a/synapse_invite_checker/invite_checker.py
+++ b/synapse_invite_checker/invite_checker.py
@@ -77,6 +77,7 @@ from synapse_invite_checker.config import DefaultPermissionConfig, InviteChecker
 from synapse_invite_checker.permissions import (
     InviteCheckerPermissionsHandler,
 )
+from synapse_invite_checker.responses import EpaRoomTimestampResults
 from synapse_invite_checker.rest.messenger_info import (
     INFO_API_PREFIX,
     MessengerFindByIkResource,
@@ -377,8 +378,15 @@ class InviteChecker:
         epa_room_grace_period = Config.parse_duration(
             insured_room_scan_section.get("grace_period", "1w")
         )
+        # Should we consider if this is not actually defined having it the same as above?
+        epa_room_invites_grace_period = Config.parse_duration(
+            insured_room_scan_section.get("invites_grace_period", "1w")
+        )
 
         _config.insured_room_scan_options.grace_period_ms = epa_room_grace_period
+        _config.insured_room_scan_options.invite_grace_period_ms = (
+            epa_room_invites_grace_period
+        )
 
         # This option is considered for all server modes unlike 'insured_only_room_scan'
         inactive_room_scan_section = config.get("inactive_room_scan", {})
@@ -837,10 +845,10 @@ class InviteChecker:
 
         return await self.store.db_pool.runInteraction("get_rooms", f)
 
-    @measure_func("get_timestamp_from_eligible_events_for_epa_room_purge")
-    async def get_timestamp_from_eligible_events_for_epa_room_purge(
+    @measure_func("define_criteria_to_kick_users_epa_mode")
+    async def define_criteria_to_kick_users_epa_mode(
         self, room_id
-    ) -> int | None:
+    ) -> EpaRoomTimestampResults:
         """
         Retrieve and parse the room PRO members that left into a timestamp of the
         latest event, or the timestamp of the create event if there were no PRO members
@@ -857,20 +865,29 @@ class InviteChecker:
             )
         )
 
-        results = set()
+        leave_event_timestamps = set()
+        invite_event_timestamps = set()
         create_event_ts = None
         # The first key is "type", but it got filtered to only membership above
         for (state_type, state_key), event in state_mapping.items():
             if state_type == EventTypes.Create:
                 create_event_ts = event.origin_server_ts
-            elif (
-                state_type == EventTypes.Member and event.membership == Membership.LEAVE
-            ):
+
+            elif state_type == EventTypes.Member:
                 users_domain = UserID.from_string(state_key).domain
                 if not await self.is_domain_insurance(users_domain):
-                    results.add(event.origin_server_ts)
+                    if event.membership == Membership.LEAVE:
+                        leave_event_timestamps.add(event.origin_server_ts)
 
-        return max(results) if results else create_event_ts
+                    elif event.membership == Membership.INVITE:
+                        invite_event_timestamps.add(event.origin_server_ts)
+
+        return EpaRoomTimestampResults(
+            self.config.insured_room_scan_options,
+            max(invite_event_timestamps) if invite_event_timestamps else None,
+            max(leave_event_timestamps) if leave_event_timestamps else None,
+            create_event_ts,
+        )
 
     @measure_func("get_timestamp_of_last_eligible_activity_in_room")
     async def get_timestamp_of_last_eligible_activity_in_room(
@@ -1126,29 +1143,31 @@ class InviteChecker:
 
                 # only shut down rooms that only have EPA hosts in them
                 if await self.have_all_pro_hosts_left(room_id):
-                    last_user_left_timestamp: int | None = (
-                        await self.get_timestamp_from_eligible_events_for_epa_room_purge(
-                            room_id
-                        )
+                    epa_room_result = await self.define_criteria_to_kick_users_epa_mode(
+                        room_id
                     )
+                    current_time = self.api._hs.get_clock().time_msec()
 
-                    if last_user_left_timestamp is None:
-                        # This is our sign of room either mid-creation/broken
-                        # Just skip this room, as there are no events to change to leave
-                        # and it will be purged automatically below
+                    if (
+                        epa_room_result.should_kick_because_leave(current_time)
+                        or epa_room_result.should_kick_because_invite(current_time)
+                        or epa_room_result.should_kick_because_no_activity_since_creation(
+                            current_time
+                        )
+                    ):
+                        await self.kick_all_local_users(room_id)
+
+                    elif (
+                        epa_room_result.no_appropriate_member_events()
+                        and epa_room_result.room_creation_ts is None
+                    ):
+                        # This is our sign of room either mid-creation or broken.
+                        # Just skip this room; there are no events to change to leave.
+                        # It will be purged automatically below
                         logger.warning(
                             "Not kicking users from room during ePA user room scan because it contained no events: %s",
                             room_id,
                         )
-
-                        continue
-
-                    if (
-                        last_user_left_timestamp
-                        + self.config.insured_room_scan_options.grace_period_ms
-                        <= self.api._hs.get_clock().time_msec()
-                    ):
-                        await self.kick_all_local_users(room_id)
 
         if self.config.inactive_room_scan_options.enabled:
             for room_id in all_room_ids:

--- a/synapse_invite_checker/responses.py
+++ b/synapse_invite_checker/responses.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2025 Famedly
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+from dataclasses import dataclass
+
+from synapse_invite_checker.config import InsuredOnlyRoomScanConfig
+
+
+# This belongs in types.py, but due to circular imports it does not like living there.
+# Between DefaultPermissionConfig and InsuredOnlyRoomScanConfig, they are not happy.
+# This place is better than sticking it in config.py to make the imports happy
+@dataclass(slots=True)
+class EpaRoomTimestampResults:
+    """
+    Collection of timestamps and helpers to decide if a room should have members removed.
+    Used for EPA server rooms. Recall that invite/leave timestamps are *only* seeded
+    from pro users membership events
+
+    Attributes:
+        config: The insured only room scan config section from the invite checker
+        last_invite_in_room: The timestamp for the newest 'invite' membership in the
+            room. Only used if there was no detected 'leave' event.
+        last_leave_in_room: The timestamp of the newest 'leave' membership in the room.
+            The preferred timestamp to acquire.
+        room_creation_ts: If nothing else, use the room creation as a sentinel. The slim
+            possibility exists that no 'leave' event exists and any 'invite' may have
+            failed. This is allowed to give a user time to try again before they do not
+            have access to this room removed.
+    """
+
+    config: InsuredOnlyRoomScanConfig
+    last_invite_in_room: int | None = None
+    last_leave_in_room: int | None = None
+    room_creation_ts: int | None = None
+
+    def should_kick_because_leave(self, time_now: int) -> bool:
+        return self.last_leave_in_room is not None and (
+            self.last_leave_in_room + self.config.grace_period_ms <= time_now
+        )
+
+    def should_kick_because_invite(self, time_now: int) -> bool:
+        return self.last_invite_in_room is not None and (
+            self.last_invite_in_room + self.config.invite_grace_period_ms <= time_now
+        )
+
+    def should_kick_because_creation_event(self, time_now: int) -> bool:
+        # For lack of a clearer option, just use the generic grace period here
+        return self.room_creation_ts is not None and (
+            self.room_creation_ts + self.config.grace_period_ms <= time_now
+        )
+
+    def no_appropriate_member_events(self) -> bool:
+        return self.last_invite_in_room is None and self.last_leave_in_room is None
+
+    def should_kick_because_no_activity_since_creation(self, time_now: int) -> bool:
+        if self.last_invite_in_room is None and self.last_leave_in_room is None:
+            return self.should_kick_because_creation_event(time_now)
+
+        # In the unlikely event of there being no invites or leave events, and somehow
+        # there is no creation event either, return False so that the room scan skips
+        # this room for epa servers. It should still be detected by the room purge scan.
+        return False

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -65,6 +65,7 @@ class InsuredOnlyRoomScanTaskTestCase(FederatingModuleApiTestCase):
                 "insured_only_room_scan": {
                     "enabled": True,
                     "grace_period": "6h",
+                    "invites_grace_period": "6h",
                 },
                 # Enabled to test broken rooms being ignored(but later purged correctly)
                 # We don't worry about the grace_period as it will not apply
@@ -93,21 +94,33 @@ class InsuredOnlyRoomScanTaskTestCase(FederatingModuleApiTestCase):
         self.inject_servers_signing_key(INSURANCE_DOMAIN_IN_LIST)
         self.inject_servers_signing_key(SERVER_NAME_FROM_LIST)
 
-    @parameterized.expand([("pro_join_and_leave", True), ("pro_never_join", False)])
+    @parameterized.expand(
+        [
+            ("pro_join_and_leave", True, True),
+            ("pro_never_join", False, True),
+            ("pro_never_invited_or_joined", False, False),
+        ]
+    )
     def test_room_scan_detects_epa_rooms(
-        self, pro_activity: str, pro_join: bool
+        self, pro_activity: str, pro_join: bool, pro_invited: bool
     ) -> None:
         """
-        Test that a room is deleted when a single EPA user and a single PRO user are in
-        a room, but the PRO user leaves. Also test the same scenario, but if the PRO user
-        never joined/left to test that 'maybe broken' rooms are detected
+        Test that a room is handled as appropriately with a single EPA user and a single
+        PRO user. Also test if the PRO user never joined/left(to test that 'maybe broken'
+        rooms) and rooms with no invites at all.
         """
-        # Make a room and invite the doctor
-        room_id = self.create_local_room(
-            self.user_d, [self.remote_pro_user], is_public=False
-        )
+        # Make a room...
+        room_id = self.create_local_room(self.user_d, [], is_public=False)
         assert room_id is not None, "Room should be created"
 
+        # ...then (maybe) invite the doctor
+        if pro_invited:
+            self.helper.invite(
+                room_id,
+                self.user_d,
+                self.remote_pro_user,
+                tok=self.map_user_id_to_token[self.user_d],
+            )
         is_room_blocked = self.get_success_or_raise(self.store.is_room_blocked(room_id))
         # Needs to be either None or False
         assert not is_room_blocked, "Room should not be blocked yet(try 1)"


### PR DESCRIPTION
Fixes: 
* famedly/product-management#3160

Adds a new sub-option in `insured_only_room_scan` to grant a separate grace period to invites

```
insured_only_room_scan:
  invite_grace_period: "1w"
```
Uses the same Duration Parsing and default as `grace_period`