### PR TITLE
chore: Add mypy config and fix mypy errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,14 @@ matrix.database.env-vars = [
   { key = "SYNAPSE_POSTGRES_PASSWORD", value = "postgres", if = ["postgres"] },
 ]
 
+[tool.hatch.envs.types]
+extra-dependencies = [
+  "mypy>=1.0.0",
+]
+
+[tool.hatch.envs.types.scripts]
+check = "mypy --ignore-missing-imports --install-types --non-interactive {args:synapse_invite_checker}"
+
 [tool.coverage.run]
 branch = true
 parallel = true

--- a/synapse_invite_checker/config.py
+++ b/synapse_invite_checker/config.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 from dataclasses import dataclass, field
-
+from typing import Optional
 
 from synapse_invite_checker.types import DefaultPermissionConfig, TimType
 
@@ -52,4 +52,4 @@ class InviteCheckerConfig:
     override_public_room_federation: bool = True
     prohibit_world_readable_rooms: bool = True
     block_invites_into_dms: bool = True
-    default_permissions: DefaultPermissionConfig = None
+    default_permissions: Optional[DefaultPermissionConfig] = None

--- a/synapse_invite_checker/invite_checker.py
+++ b/synapse_invite_checker/invite_checker.py
@@ -17,7 +17,7 @@ import functools
 import logging
 from collections.abc import Collection
 from contextlib import suppress
-from typing import Any, Literal, cast
+from typing import Any, Literal, cast, Mapping
 from urllib.parse import quote, urlparse
 
 from cachetools import TTLCache, keys
@@ -70,7 +70,7 @@ from synapse.util.metrics import measure_func
 from twisted.internet.defer import Deferred
 from twisted.internet.ssl import PrivateCertificate, optionsForClientTLS, platformTrust
 from twisted.web.client import HTTPConnectionPool
-from twisted.web.iweb import IPolicyForHTTPS
+from twisted.web.iweb import IPolicyForHTTPS, IAgent
 from zope.interface import implementer
 
 from synapse_invite_checker.config import DefaultPermissionConfig, InviteCheckerConfig
@@ -153,9 +153,7 @@ class MtlsPolicy:
         )
 
     def creatorForNetloc(self, hostname: bytes, port: int):
-        assert self.url.hostname is not None
-
-        if self.url.hostname.encode("utf-8") != hostname or self.url.port != port:
+        if self.url.hostname and self.url.hostname.encode("utf-8") != hostname or self.url.port != port:
             logger.error(
                 "Destination mismatch: %r:%r != %r:%r",
                 self.url.hostname,
@@ -183,13 +181,16 @@ class FederationAllowListClient(BaseHttpClient):
         super().__init__(hs)
 
         pool = HTTPConnectionPool(self.reactor)
-        self.agent = ProxyAgent(
+
+        mstls_policy = MtlsPolicy(config)
+        proxy_agent = ProxyAgent(
             self.reactor,
             hs.get_reactor(),
             connectTimeout=15,
-            contextFactory=MtlsPolicy(config),
+            contextFactory=cast(IPolicyForHTTPS, mstls_policy),
             pool=pool,
         )
+        self.agent = cast(IAgent, proxy_agent)
 
 
 BASE_API_PREFIX = "/_synapse/client/com.famedly/tim"
@@ -205,9 +206,10 @@ class InviteChecker:
         self.config = config
         # Can not do this as part of parse_config() as there is no access to the server
         # name yet
-        self.config.default_permissions.maybe_update_server_exceptions(
-            self.api._hs.config.server.server_name
-        )
+        if self.config.default_permissions:
+            self.config.default_permissions.maybe_update_server_exceptions(
+                self.api._hs.config.server.server_name
+            )
 
         self.federation_list_client = FederationAllowListClient(api._hs, self.config)
 
@@ -244,12 +246,13 @@ class InviteChecker:
 
         # Make sure this doesn't get initialized until after the default permissions
         # were potentially modified to account for the local server template
-        self.permissions_handler = InviteCheckerPermissionsHandler(
-            self.api,
-            self.config,
-            self.is_domain_insurance,
-            self.config.default_permissions,
-        )
+        if self.config.default_permissions:
+            self.permissions_handler = InviteCheckerPermissionsHandler(
+                self.api,
+                self.config,
+                self.is_domain_insurance,
+                self.config.default_permissions,
+            )
 
         self.task_scheduler = api._hs.get_task_scheduler()
 
@@ -499,7 +502,7 @@ class InviteChecker:
 
         chain = load_certificate(
             FILETYPE_ASN1,
-            await self._raw_gematik_intermediate_cert_fetch(jwskey.get_issuer().CN),
+            await self._raw_gematik_intermediate_cert_fetch(jwskey.get_issuer().CN or ""),
         )
         store_ctx = X509StoreContext(store, jwskey, chain=[chain])
         store_ctx.verify_certificate()
@@ -588,7 +591,7 @@ class InviteChecker:
 
     async def check_event_allowed(
         self, event: EventBase, context: StateMap[EventBase]
-    ) -> tuple[bool, dict | None] | None:
+    ) -> tuple[bool, dict | None]:
         """
         Check the 'event' to see if it is allowed to exist. This takes place before
         the event is actually stored.
@@ -622,9 +625,10 @@ class InviteChecker:
                 return False, None
             creation_event = context.get((EventTypes.Create, ""))
             # `m.federate` defaults to True if unspecified
-            federated_flag = creation_event["content"].get(
-                EventContentFields.FEDERATE, True
-            )
+            if creation_event and creation_event["content"]:
+                federated_flag = creation_event["content"].get(
+                    EventContentFields.FEDERATE, True
+                )
             # Remember to account for the override disabler
             if federated_flag and self.config.override_public_room_federation:
                 return False, None
@@ -653,7 +657,7 @@ class InviteChecker:
         """
         # preset can be any of "private_chat", "trusted_private_chat" or "public_chat"
         # Do not allow "public_chat". Default is based on setting of visibility
-        room_preset: str = request_content.get("preset")
+        room_preset: str = request_content.get("preset", "")
         # visibility can be either "public" or "private". If not included, it defaults to "private"
         room_visibility: str = request_content.get("visibility", "private")
         # Determine based on above that the room is probably public
@@ -864,7 +868,7 @@ class InviteChecker:
 
         Returns None when no events were found for a room
         """
-        state_mapping: dict[tuple[str, str], EventBase] = (
+        state_mapping: StateMap[EventBase] = (
             await self.api._storage_controllers.state.get_current_state(
                 room_id,
                 StateFilter.from_types(
@@ -1083,7 +1087,7 @@ class InviteChecker:
         around in the database, try it again
         """
         if len(await self.get_delete_tasks_by_room(room_id)) > 0:
-            logger.warning("Purge already in progress or scheduled for %s" % (room_id,))
+            logger.warning("Purge already in progress or scheduled for %s", room_id)
             return
 
         shutdown_params = ShutdownRoomParams(
@@ -1235,7 +1239,7 @@ class InviteChecker:
         Returns: bool representing if the hosts present are all non-Pro servers
 
         """
-        hosts = await self.api._store.get_current_hosts_in_room(room_id)
+        hosts = await self.api._store.get_current_hosts_in_room(room_id=room_id)  # type: ignore[call-arg]
         for host in hosts:
             if not await self.is_domain_insurance(host):
                 return False

--- a/synapse_invite_checker/permissions.py
+++ b/synapse_invite_checker/permissions.py
@@ -21,7 +21,6 @@ from synapse.types import UserID
 
 from synapse_invite_checker.config import InviteCheckerConfig
 from synapse_invite_checker.types import (
-    DefaultPermissionConfig,
     PermissionConfig,
     PermissionConfigType,
     TimType,
@@ -44,7 +43,7 @@ class InviteCheckerPermissionsHandler:
         api: ModuleApi,
         config: InviteCheckerConfig,
         is_domain_insurance_cb: Callable[[str], Awaitable[bool]],
-        default_perms_from_config: DefaultPermissionConfig,
+        default_perms_from_config: PermissionConfig,
     ) -> None:
         self.api = api
         self.config = config

--- a/synapse_invite_checker/types.py
+++ b/synapse_invite_checker/types.py
@@ -15,7 +15,7 @@
 from dataclasses import dataclass
 from enum import Enum, auto
 from functools import cached_property
-from typing import Annotated, Any, Final
+from typing import Annotated, Any, Final, Optional
 
 from pydantic import (
     BaseModel,
@@ -49,14 +49,14 @@ class PermissionConfig(BaseModel):
     # InviteCheckerPermissionsHandler.get_permissions() for where it is set now.
     # TLDR: this will not be an important detail after migrations have run as it will
     # always be set during class instantiation
-    defaultSetting: PermissionDefaultSetting = None
+    defaultSetting: PermissionDefaultSetting = PermissionDefaultSetting.BLOCK_ALL
     # If any of these three exists, they should contain a dict with the key as the
     # exception and then an empty dict inside "for future expansion"
-    serverExceptions: Annotated[dict[str, dict], Field(default_factory=dict)] = None
+    serverExceptions: Annotated[dict[str, dict], Field(default_factory=dict)] = {}
     # If there is a key inside userExceptions, it needs to be sure to start with a '@'.
     # Should we validate this or trust the client app does the right thing?
-    userExceptions: Annotated[dict[str, dict], Field(default_factory=dict)] = None
-    groupExceptions: Annotated[list[dict[str, str]], Field(default_factory=list)] = None
+    userExceptions: Annotated[dict[str, dict], Field(default_factory=dict)] = {}
+    groupExceptions: Annotated[list[dict[str, str]], Field(default_factory=list)] = []
 
     def dump(self) -> dict[str, Any]:
         # exclude_none=True strips out the attributes that are None so they do translate
@@ -129,9 +129,9 @@ class DefaultPermissionConfig(PermissionConfig):
 
         Returns: None
         """
-        if LOCAL_SERVER_TEMPLATE in self.serverExceptions:
+        if self.serverExceptions and LOCAL_SERVER_TEMPLATE in self.serverExceptions:
             self.serverExceptions.setdefault(
-                local_server_name, self.serverExceptions.get(LOCAL_SERVER_TEMPLATE)
+                local_server_name, self.serverExceptions.get(LOCAL_SERVER_TEMPLATE, {})
             )
             del self.serverExceptions[LOCAL_SERVER_TEMPLATE]
 
@@ -146,7 +146,7 @@ class FederationDomain(BaseModel):
     timAnbieter: str | None  # noqa: N815
     isInsurance: bool  # noqa: N815
     # ik gets marked as 'strict=False' as not all domains will have that data
-    ik: Annotated[list[str], Field(default_factory=list, strict=False)] = None
+    ik: Annotated[list[str], Field(default_factory=list, strict=False)] = []
 
 
 class FederationList(BaseModel):
@@ -156,7 +156,7 @@ class FederationList(BaseModel):
 
     domainList: list[FederationDomain]  # noqa: N815
 
-    @computed_field
+    @computed_field # type: ignore[prop-decorator]
     @cached_property
     def _domains_on_list(self) -> set[str]:
         """
@@ -164,7 +164,7 @@ class FederationList(BaseModel):
         """
         return {domain_data.domain for domain_data in self.domainList}
 
-    @computed_field
+    @computed_field # type: ignore[prop-decorator]
     @cached_property
     def _insurance_domains_on_list(self) -> set[str]:
         """
@@ -176,7 +176,7 @@ class FederationList(BaseModel):
             if domain_data.isInsurance
         }
 
-    @computed_field
+    @computed_field # type: ignore[prop-decorator]
     @cached_property
     def _ik_to_domain(self) -> dict[str, str]:
         """


### PR DESCRIPTION
Ticket: Enable more linting in invite checker
[#2949](https://github.com/famedly/product-management/issues/2949)

It is including a config on `pyproject.toml`

- [ ] Fix the errors reported by `hatch fmt` or add appropriate suppressions with proper comments
- [x] Enable mypy and fix reported type errors: Fix the errors reported by `hatch run types:check` or add appropriate suppressions with proper comments
- [ ] Add both of those linters to our CI jobs

I will continue work on more fixes for `hatch fmt`, and then work on the Github actions.