### PR TITLE
release: v0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.6] - 2025-07-03
+
+- chore: Allow reactions only containing a single grapheme cluster (Jason Little)
+- chore: fix type errors in `/synapse_invite_checker`, add mypy to github workflows, add hatch command `lint` (Soyoung Kim)
+
 ## [0.4.5] - 2025-05-26
 
 This release properly accounts for invites in the epa room scan. This behaviour

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   # TODO: Remove this dependency when we can
   "Twisted==24.7.0"
 ]
-version = "0.4.5"
+version = "0.4.6"
 
 [project.urls]
 Documentation = "https://github.com/famedly/synapse-invite-checker#synapse-invite-checker"

--- a/synapse_invite_checker/invite_checker.py
+++ b/synapse_invite_checker/invite_checker.py
@@ -204,7 +204,7 @@ BASE_API_PREFIX = "/_synapse/client/com.famedly/tim"
 
 
 class InviteChecker:
-    __version__ = "0.4.5"
+    __version__ = "0.4.6"
 
     def __init__(self, config: InviteCheckerConfig, api: ModuleApi):
         self.api = api


### PR DESCRIPTION
## Release [0.4.6] - 2025-07-03

- chore: Allow reactions only containing a single grapheme cluster (Jason Little)
- chore: fix type errors in `/synapse_invite_checker`, add mypy to github workflows, add hatch command `lint` (Soyoung Kim)
