### PR TITLE
chore: remove pinned version of Twisted

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,6 @@ dependencies = [
   "pyopenssl",
   # For the emoji reaction restrictions
   "emoji",
-  # We need to pin this because of https://github.com/element-hq/synapse/issues/17882
-  # TODO: Remove this dependency when we can
-  "Twisted==24.7.0"
 ]
 version = "0.4.7"
 


### PR DESCRIPTION
This is not needed as of Synapse version v1.133.0

This got forgotten about for a bit, so now...
Depends on #98 