### PR TITLE
chore: test more room versions in tests, from "9" to "12"

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -17,6 +17,7 @@ import json
 import logging
 from collections.abc import Iterable
 from http import HTTPStatus
+from random import random
 from typing import TYPE_CHECKING, Any, ClassVar
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -216,7 +217,8 @@ class FakeInviteResponse:
 class FederatingModuleApiTestCase(synapsetest.FederatingHomeserverTestCase):
     server_name_for_this_server = SERVER_NAME_FROM_LIST
     OTHER_SERVER_NAME = INSURANCE_DOMAIN_IN_LIST
-    ROOM_VERSION = "10"
+    DEFAULT_ROOM_VERSION = "10"
+    ALLOWED_ROOM_VERSIONS = ["9", "10"]
     TIM_VERSION = TimVersion.V1_1
 
     @classmethod
@@ -298,6 +300,10 @@ class FederatingModuleApiTestCase(synapsetest.FederatingHomeserverTestCase):
 
     def default_config(self) -> dict[str, Any]:
         conf = super().default_config()
+        assert (
+            self.DEFAULT_ROOM_VERSION in KNOWN_ROOM_VERSIONS
+        ), f"Requested default room version unknown: {self.DEFAULT_ROOM_VERSION}"
+        conf["default_room_version"] = self.DEFAULT_ROOM_VERSION
         if "modules" not in conf:
             conf["modules"] = [
                 {
@@ -305,6 +311,7 @@ class FederatingModuleApiTestCase(synapsetest.FederatingHomeserverTestCase):
                     "config": {
                         "tim-type": "pro",
                         "tim_version": self.TIM_VERSION.value,
+                        "allowed_room_versions": self.ALLOWED_ROOM_VERSIONS,
                         "federation_list_url": "http://dummy.test/FederationList/federationList.jws",
                         "federation_localization_url": "http://dummy.test/localization",
                         "federation_list_client_cert": "tests/certs/client.pem",
@@ -330,13 +337,15 @@ class FederatingModuleApiTestCase(synapsetest.FederatingHomeserverTestCase):
             self.inv_checker.permissions_handler.update_permissions(owning_user, perms)
         )
 
-    def _make_join(self, user_id: str, room_id: str) -> FakeChannel:
+    def _make_join(
+        self, user_id: str, room_id: str, room_version_str: str | None = None
+    ) -> FakeChannel:
         """Generate the make_join template"""
         users_domain = UserID.from_string(user_id).domain
         return self.make_signed_federation_request(
             "GET",
             f"/_matrix/federation/v1/make_join/{room_id}/{user_id}"
-            f"?ver={self.ROOM_VERSION}",
+            f"?ver={room_version_str or self.DEFAULT_ROOM_VERSION}",
             from_server=users_domain,
         )
 
@@ -346,13 +355,14 @@ class FederatingModuleApiTestCase(synapsetest.FederatingHomeserverTestCase):
         room_id: str,
         make_join_expected_code: int = HTTPStatus.OK,
         send_join_expected_code: int = HTTPStatus.OK,
+        room_version_str: str | None = None,
     ) -> None:
         """
         Join a remote user to a local server. Should be a complete make_join/send_join
         handshake
         """
         # First create the make_join that will need to be signed by the 'remote server'
-        join_result_channel = self._make_join(joining_user, room_id)
+        join_result_channel = self._make_join(joining_user, room_id, room_version_str)
         assert (
             join_result_channel.code == make_join_expected_code
         ), f"make_join: {join_result_channel.json_body}"
@@ -368,7 +378,7 @@ class FederatingModuleApiTestCase(synapsetest.FederatingHomeserverTestCase):
         joining_users_domain = UserID.from_string(joining_user).domain
         self.add_hashes_and_signatures_from_other_server(
             join_event_dict,
-            KNOWN_ROOM_VERSIONS[self.ROOM_VERSION],
+            KNOWN_ROOM_VERSIONS[room_version_str or self.DEFAULT_ROOM_VERSION],
             joining_users_domain,
         )
         channel = self.make_signed_federation_request(
@@ -415,6 +425,16 @@ class FederatingModuleApiTestCase(synapsetest.FederatingHomeserverTestCase):
     def create_remote_room(
         self, creator_id: str, room_version: str, is_public: bool
     ) -> str:
+        # Creating a room before version "12" means the room gets a randomly generated
+        # room id. Starting with "12" the room is based on the create event itself. To
+        # avoid arbitrary errors when doing tests that repeatedly create rooms
+        # rapid-fire, let's introduce a small time advance so that the timestamp on the
+        # room is just different enough to have a different hash than a previously
+        # created room. This should help stop errors like
+        #  "store_room with room_id=!dE_jLFdFgPIHXZuc1wZ3qVANUu4R0y8zimGAzqmbqOg failed:
+        #   UNIQUE constraint failed: rooms.room_id".
+        self.reactor.advance(random() * 2)
+
         domain = UserID.from_string(creator_id).domain
         assert (
             domain in self.map_server_name_to_signing_key
@@ -614,9 +634,11 @@ class FederatingModuleApiTestCase(synapsetest.FederatingHomeserverTestCase):
     def create_local_room(
         self,
         creating_user: str,
-        invitee_list: list[str],
         is_public: bool,
+        invitee_list: list[str] | None = None,
         override_content: dict[str, Any] | None = None,
+        room_version: str | None = None,
+        expected_code: int = HTTPStatus.OK,
     ) -> str | None:
         """
         Custom helper to send an api request with a full set of required additional room
@@ -629,10 +651,19 @@ class FederatingModuleApiTestCase(synapsetest.FederatingHomeserverTestCase):
         Returns a room_id if successful or None if not, allowing tests to give the
             assertion errors they want instead of the http response which is not useful
         """
+        # Creating a room before version "12" means the room gets a randomly generated
+        # room id. Starting with "12" the room is based on the create event itself. To
+        # avoid arbitrary errors when doing tests that repeatedly create rooms
+        # rapid-fire, let's introduce a small time advance so that the timestamp on the
+        # room is just different enough to have a different hash than a previously
+        # created room. This should help stop errors like
+        #  "store_room with room_id=!dE_jLFdFgPIHXZuc1wZ3qVANUu4R0y8zimGAzqmbqOg failed:
+        #   UNIQUE constraint failed: rooms.room_id".
+        self.reactor.advance(random() * 2)
 
         # First create the extra content, then let override_content replace/merge items.
         # extra_content will be passed to the room creation helper function
-        extra_content = construct_extra_content(creating_user, invitee_list)
+        extra_content = construct_extra_content(creating_user, invitee_list or [])
         if override_content:
             for key, value in override_content.items():
                 # initial_state is special, it's a list so we don't override it as much
@@ -658,8 +689,10 @@ class FederatingModuleApiTestCase(synapsetest.FederatingHomeserverTestCase):
             return self.helper.create_room_as(
                 creating_user,
                 is_public=is_public,
+                room_version=room_version or self.DEFAULT_ROOM_VERSION,
                 tok=self.map_user_id_to_token[creating_user],
                 extra_content=extra_content,
+                expect_code=expected_code,
             )
         except AssertionError as e:
             logger.warning(

--- a/tests/test_createrooms_local.py
+++ b/tests/test_createrooms_local.py
@@ -15,7 +15,7 @@
 from http import HTTPStatus
 from typing import Any
 
-from parameterized import parameterized
+from parameterized import parameterized, parameterized_class
 from synapse.api.constants import EventTypes, HistoryVisibility, JoinRules
 from synapse.server import HomeServer
 from synapse.util.clock import Clock
@@ -25,11 +25,22 @@ from tests.base import FederatingModuleApiTestCase
 from tests.test_utils import INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL
 
 
+@parameterized_class(
+    ("DEFAULT_ROOM_VERSION",),
+    [
+        ("9",),
+        ("10",),
+        ("11",),
+        ("12",),
+    ],
+)
 class LocalProModeCreateRoomTest(FederatingModuleApiTestCase):
     """
     These PRO server tests are for room creation process, including invite checking for
     local users and special cases that should be allowed or prevented.
     """
+
+    ALLOWED_ROOM_VERSIONS = ["9", "10", "11", "12"]
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
         super().prepare(reactor, clock, homeserver)
@@ -65,8 +76,8 @@ class LocalProModeCreateRoomTest(FederatingModuleApiTestCase):
         ]:
             room_id = self.create_local_room(
                 self.pro_user_a,
-                [invitee],
                 is_public=is_public,
+                invitee_list=[invitee],
             )
             assert (
                 room_id
@@ -78,8 +89,8 @@ class LocalProModeCreateRoomTest(FederatingModuleApiTestCase):
         ]:
             room_id = self.create_local_room(
                 self.pro_user_b,
-                [invitee],
                 is_public=is_public,
+                invitee_list=[invitee],
             )
             assert (
                 room_id
@@ -91,8 +102,8 @@ class LocalProModeCreateRoomTest(FederatingModuleApiTestCase):
         ]:
             room_id = self.create_local_room(
                 self.pro_user_d,
-                [invitee],
                 is_public=is_public,
+                invitee_list=[invitee],
             )
             assert (
                 room_id
@@ -112,8 +123,8 @@ class LocalProModeCreateRoomTest(FederatingModuleApiTestCase):
         ]:
             room_id = self.create_local_room(
                 self.pro_user_a,
-                invitee_list,
                 is_public=is_public,
+                invitee_list=invitee_list,
             )
             assert (
                 room_id is None
@@ -143,7 +154,7 @@ class LocalProModeCreateRoomTest(FederatingModuleApiTestCase):
         Test that a misbehaving client can not accidentally make their room public after
         the room was created
         """
-        room_id = self.create_local_room(self.pro_user_a, [], is_public=is_public)
+        room_id = self.create_local_room(self.pro_user_a, is_public=is_public)
         assert room_id, f"{label} room should be created"
         # This should be ALLOWED for an already public room, it's silly but is idempotent
         self.helper.send_state(
@@ -162,7 +173,7 @@ class LocalProModeCreateRoomTest(FederatingModuleApiTestCase):
         Test that a misbehaving client can not accidentally make their room visible
         after the room was created
         """
-        room_id = self.create_local_room(self.pro_user_a, [], is_public=is_public)
+        room_id = self.create_local_room(self.pro_user_a, is_public=is_public)
         assert room_id, f"{label} room should be created"
         # This should be BAD_REQUEST for any room
         self.helper.send_state(
@@ -179,7 +190,7 @@ class LocalProModeCreateRoomTest(FederatingModuleApiTestCase):
         but users can override this setting during room creation
         """
         # Test 1: Private room created without explicit history_visibility should default to "invited"
-        room_id_private = self.create_local_room(self.pro_user_a, [], is_public=False)
+        room_id_private = self.create_local_room(self.pro_user_a, is_public=False)
         assert room_id_private, "Private room should be created"
 
         # Get the history visibility state event
@@ -193,7 +204,7 @@ class LocalProModeCreateRoomTest(FederatingModuleApiTestCase):
         ), "Default history visibility should be 'invited'"
 
         # Test 2: Public room created without explicit history_visibility should default to "invited"
-        room_id_public = self.create_local_room(self.pro_user_a, [], is_public=True)
+        room_id_public = self.create_local_room(self.pro_user_a, is_public=True)
         assert room_id_public, "Public room should be created"
 
         # Get the history visibility state event
@@ -215,7 +226,7 @@ class LocalProModeCreateRoomTest(FederatingModuleApiTestCase):
         override_content = {"initial_state": [custom_history_visibility]}
 
         room_id_private_custom = self.create_local_room(
-            self.pro_user_a, [], is_public=False, override_content=override_content
+            self.pro_user_a, is_public=False, override_content=override_content
         )
         assert (
             room_id_private_custom
@@ -240,7 +251,7 @@ class LocalProModeCreateRoomTest(FederatingModuleApiTestCase):
         override_content = {"initial_state": [custom_history_visibility]}
 
         room_id_public_custom = self.create_local_room(
-            self.pro_user_a, [], is_public=True, override_content=override_content
+            self.pro_user_a, is_public=True, override_content=override_content
         )
         assert (
             room_id_public_custom
@@ -262,8 +273,8 @@ class LocalProModeCreateRoomTest(FederatingModuleApiTestCase):
         """
         room_id = self.create_local_room(
             self.pro_user_a,
-            [self.pro_user_b],
             is_public=False,
+            invitee_list=[self.pro_user_b],
             override_content={"type": "de.gematik.tim.roomtype.default.v2"},
         )
         assert (
@@ -271,12 +282,22 @@ class LocalProModeCreateRoomTest(FederatingModuleApiTestCase):
         ), "Room with de.gematik.tim.roomtype.default.v2 type should not be created"
 
 
+@parameterized_class(
+    ("DEFAULT_ROOM_VERSION",),
+    [
+        ("9",),
+        ("10",),
+        ("11",),
+        ("12",),
+    ],
+)
 class LocalEpaModeCreateRoomTest(FederatingModuleApiTestCase):
     """
     These EPA server tests are for room creation process, including invite checking for
     local users and special cases that should be allowed or prevented.
     """
 
+    ALLOWED_ROOM_VERSIONS = ["9", "10", "11", "12"]
     server_name_for_this_server = INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
@@ -310,8 +331,8 @@ class LocalEpaModeCreateRoomTest(FederatingModuleApiTestCase):
         ]:
             room_id = self.create_local_room(
                 self.epa_user_d,
-                [invitee],
                 is_public=is_public,
+                invitee_list=[invitee],
             )
             assert (
                 room_id is None
@@ -328,8 +349,8 @@ class LocalEpaModeCreateRoomTest(FederatingModuleApiTestCase):
         invitee_list = [self.epa_user_e, self.epa_user_f]
         room_id = self.create_local_room(
             self.epa_user_d,
-            invitee_list,
             is_public=is_public,
+            invitee_list=invitee_list,
         )
         assert (
             room_id is None
@@ -356,7 +377,7 @@ class LocalEpaModeCreateRoomTest(FederatingModuleApiTestCase):
         initial_state = {"initial_state": [join_rule_event]}
 
         room_id = self.create_local_room(
-            self.epa_user_d, [], is_public=False, override_content=initial_state
+            self.epa_user_d, is_public=False, override_content=initial_state
         )
         assert (
             room_id is None
@@ -374,7 +395,7 @@ class LocalEpaModeCreateRoomTest(FederatingModuleApiTestCase):
         initial_state = {"initial_state": [history_visibility]}
 
         room_id = self.create_local_room(
-            self.epa_user_d, [], is_public=False, override_content=initial_state
+            self.epa_user_d, is_public=False, override_content=initial_state
         )
         # Without the blocking put in place, this fails for private rooms
         assert room_id is None, "Private room should NOT have been created"
@@ -394,7 +415,7 @@ class LocalEpaModeCreateRoomTest(FederatingModuleApiTestCase):
         Test that a misbehaving insurance client can not set forbidden join rules
         after room was created
         """
-        room_id = self.create_local_room(self.epa_user_d, [], is_public=False)
+        room_id = self.create_local_room(self.epa_user_d, is_public=False)
         assert room_id, "Private room should be created"
         # This should be BAD_REQUEST
         self.helper.send_state(
@@ -410,7 +431,7 @@ class LocalEpaModeCreateRoomTest(FederatingModuleApiTestCase):
         Test that a misbehaving insurance client can not accidentally make their room
         world_readable after room was created. Expects 400 M_INVALID_ROOM_STATE.
         """
-        room_id = self.create_local_room(self.epa_user_d, [], is_public=False)
+        room_id = self.create_local_room(self.epa_user_d, is_public=False)
         assert room_id, "Private room should be created"
         # This should be BAD_REQUEST
         self.helper.send_state(
@@ -447,7 +468,7 @@ class LocalEpaModeCreateRoomTest(FederatingModuleApiTestCase):
         but users can override this setting during room creation
         """
         # Test 1: Room created without explicit history_visibility should default to "invited"
-        room_id = self.create_local_room(self.epa_user_d, [], is_public=False)
+        room_id = self.create_local_room(self.epa_user_d, is_public=False)
         assert room_id, "Room should be created"
 
         # Get the history visibility state event
@@ -469,7 +490,7 @@ class LocalEpaModeCreateRoomTest(FederatingModuleApiTestCase):
         override_content = {"initial_state": [custom_history_visibility]}
 
         room_id_custom = self.create_local_room(
-            self.epa_user_d, [], is_public=False, override_content=override_content
+            self.epa_user_d, is_public=False, override_content=override_content
         )
         assert room_id_custom, "Room with custom history visibility should be created"
 
@@ -489,8 +510,8 @@ class LocalEpaModeCreateRoomTest(FederatingModuleApiTestCase):
         """
         room_id = self.create_local_room(
             self.epa_user_d,
-            [self.epa_user_e],
             is_public=False,
+            invitee_list=[self.epa_user_e],
             override_content={"type": "de.gematik.tim.roomtype.default.v2"},
         )
         assert (

--- a/tests/test_createrooms_remote.py
+++ b/tests/test_createrooms_remote.py
@@ -14,7 +14,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 from typing import Any
 
-from parameterized import parameterized
+from parameterized import parameterized, parameterized_class
 from synapse.server import HomeServer
 from synapse.util.clock import Clock
 from twisted.internet.testing import MemoryReactor
@@ -28,11 +28,20 @@ from tests.test_utils import (
 )
 
 
+@parameterized_class(
+    ("DEFAULT_ROOM_VERSION",),
+    [
+        ("9",),
+        ("10",),
+        ("11",),
+        ("12",),
+    ],
+)
 class RemoteProModeCreateRoomTest(FederatingModuleApiTestCase):
     """
     These PRO server tests are for room creation process, to demonstrate that rooms can
     be created when inviting during it's processing.
-    NOTE: Event though the server is designated as "block all" the outgoing invites are
+    NOTE: Even though the server is designated as "block all" the outgoing invites are
     allowed as invites are only checked by the receiving user. This means the room will
     be created, but empty of the other user. Public rooms with invites to a remote user
     will still fail as expected
@@ -47,6 +56,7 @@ class RemoteProModeCreateRoomTest(FederatingModuleApiTestCase):
     remote_epa_user = f"@alice:{INSURANCE_DOMAIN_IN_LIST}"
     remote_non_fed_list_user = "@rando:fake-website.com"
     # SERVER_NAME_FROM_LIST = "tim.test.gematik.de"
+    ALLOWED_ROOM_VERSIONS = ["9", "10", "11", "12"]
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
         super().prepare(reactor, clock, homeserver)
@@ -78,8 +88,8 @@ class RemoteProModeCreateRoomTest(FederatingModuleApiTestCase):
         for remote_user in (self.remote_pro_user, self.remote_epa_user):
             room_id = self.create_local_room(
                 self.pro_user_a,
-                [remote_user],
                 is_public=is_public,
+                invitee_list=[remote_user],
             )
             assert (
                 room_id is not None
@@ -95,8 +105,8 @@ class RemoteProModeCreateRoomTest(FederatingModuleApiTestCase):
         for local_user in (self.pro_user_a, self.pro_user_b):
             room_id = self.create_local_room(
                 local_user,
-                [self.remote_non_fed_list_user],
                 is_public=is_public,
+                invitee_list=[self.remote_non_fed_list_user],
             )
             assert (
                 room_id is None
@@ -124,8 +134,8 @@ class RemoteProModeCreateRoomTest(FederatingModuleApiTestCase):
         ]:
             room_id = self.create_local_room(
                 self.pro_user_a,
-                invitee_list,
                 is_public=is_public,
+                invitee_list=invitee_list,
             )
             assert (
                 room_id is None
@@ -151,14 +161,23 @@ class RemoteProModeCreateRoomTest(FederatingModuleApiTestCase):
         ]:
             room_id = self.create_local_room(
                 self.pro_user_a,
-                invitee_list,
                 is_public=is_public,
+                invitee_list=invitee_list,
             )
             assert (
                 room_id is None
             ), f"User-HBA {label} room should not be created(after permission) with invites to: {invitee_list}"
 
 
+@parameterized_class(
+    ("DEFAULT_ROOM_VERSION",),
+    [
+        ("9",),
+        ("10",),
+        ("11",),
+        ("12",),
+    ],
+)
 class RemoteEpaModeCreateRoomTest(FederatingModuleApiTestCase):
     """
     These EPA server tests are for room creation process, including invite checking for
@@ -175,6 +194,7 @@ class RemoteEpaModeCreateRoomTest(FederatingModuleApiTestCase):
     remote_epa_user = f"@alice:{INSURANCE_DOMAIN_IN_LIST}"
     remote_non_fed_list_user = "@rando:fake-website.com"
     server_name_for_this_server = INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL
+    ALLOWED_ROOM_VERSIONS = ["9", "10", "11", "12"]
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
         super().prepare(reactor, clock, homeserver)
@@ -203,8 +223,8 @@ class RemoteEpaModeCreateRoomTest(FederatingModuleApiTestCase):
         """
         room_id = self.create_local_room(
             self.epa_user_d,
-            [self.remote_pro_user],
             is_public=is_public,
+            invitee_list=[self.remote_pro_user],
         )
         assert (
             (room_id is None) if is_public else room_id
@@ -218,8 +238,8 @@ class RemoteEpaModeCreateRoomTest(FederatingModuleApiTestCase):
         """
         room_id = self.create_local_room(
             self.epa_user_d,
-            [self.remote_epa_user],
             is_public=is_public,
+            invitee_list=[self.remote_epa_user],
         )
         assert (
             room_id is None
@@ -231,8 +251,8 @@ class RemoteEpaModeCreateRoomTest(FederatingModuleApiTestCase):
 
         room_id = self.create_local_room(
             self.epa_user_d,
-            [self.remote_epa_user],
             is_public=is_public,
+            invitee_list=[self.remote_epa_user],
         )
         assert (
             room_id is None
@@ -247,8 +267,8 @@ class RemoteEpaModeCreateRoomTest(FederatingModuleApiTestCase):
         """
         room_id = self.create_local_room(
             self.epa_user_d,
-            [self.remote_non_fed_list_user],
             is_public=is_public,
+            invitee_list=[self.remote_non_fed_list_user],
         )
         assert (
             room_id is None
@@ -260,8 +280,8 @@ class RemoteEpaModeCreateRoomTest(FederatingModuleApiTestCase):
 
         room_id = self.create_local_room(
             self.epa_user_d,
-            [self.remote_non_fed_list_user],
             is_public=is_public,
+            invitee_list=[self.remote_non_fed_list_user],
         )
         assert (
             room_id is None
@@ -283,8 +303,8 @@ class RemoteEpaModeCreateRoomTest(FederatingModuleApiTestCase):
         ]:
             room_id = self.create_local_room(
                 self.epa_user_e,
-                invitee_list,
                 is_public=is_public,
+                invitee_list=invitee_list,
             )
             assert (
                 room_id is None
@@ -307,8 +327,8 @@ class RemoteEpaModeCreateRoomTest(FederatingModuleApiTestCase):
         ]:
             room_id = self.create_local_room(
                 self.epa_user_e,
-                invitee_list,
                 is_public=is_public,
+                invitee_list=invitee_list,
             )
             assert (
                 room_id is None

--- a/tests/test_disable_epa_communication.py
+++ b/tests/test_disable_epa_communication.py
@@ -175,7 +175,7 @@ class DisableEpaCommunicationJoinTest(FederatingModuleApiTestCase):
         Joining via an invite from an ePA domain must be blocked.
         """
         epa_user = f"@alice:{INSURANCE_DOMAIN_IN_LIST}"
-        room_id = self.create_local_room(self.pro_user_a, [], is_public=False)
+        room_id = self.create_local_room(self.pro_user_a, is_public=False)
         assert room_id is not None
 
         p_invite, p_event = self._patched_store(epa_user)
@@ -194,7 +194,7 @@ class DisableEpaCommunicationJoinTest(FederatingModuleApiTestCase):
         Joining via an invite from a non-ePA domain must not be blocked.
         """
         pro_user = f"@bob:{DOMAIN_IN_LIST}"
-        room_id = self.create_local_room(self.pro_user_a, [], is_public=False)
+        room_id = self.create_local_room(self.pro_user_a, is_public=False)
         assert room_id is not None
 
         p_invite, p_event = self._patched_store(pro_user)

--- a/tests/test_local_invites.py
+++ b/tests/test_local_invites.py
@@ -15,7 +15,7 @@
 from http import HTTPStatus
 from typing import Any
 
-from parameterized import parameterized
+from parameterized import parameterized, parameterized_class
 from synapse.server import HomeServer
 from synapse.util.clock import Clock
 from twisted.internet.testing import MemoryReactor
@@ -25,11 +25,22 @@ from tests.base import FederatingModuleApiTestCase
 from tests.test_utils import INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL
 
 
+@parameterized_class(
+    ("DEFAULT_ROOM_VERSION",),
+    [
+        ("9",),
+        ("10",),
+        ("11",),
+        ("12",),
+    ],
+)
 class LocalProModeInviteTest(FederatingModuleApiTestCase):
     """
     These PRO server tests are for invites that happen after the room creation process
     has completed
     """
+
+    ALLOWED_ROOM_VERSIONS = ["9", "10", "11", "12"]
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
         super().prepare(reactor, clock, homeserver)
@@ -80,7 +91,6 @@ class LocalProModeInviteTest(FederatingModuleApiTestCase):
     ) -> None:
         room_id = self.create_local_room(
             self.user_b,
-            [],
             is_public=is_public,
         )
         assert room_id is not None, "Room should have been created"
@@ -137,7 +147,6 @@ class LocalProModeInviteTest(FederatingModuleApiTestCase):
     ) -> None:
         room_id = self.create_local_room(
             self.user_b,
-            [],
             is_public=is_public,
         )
         assert room_id is not None, "Room should have been created"
@@ -218,7 +227,6 @@ class LocalProModeInviteTest(FederatingModuleApiTestCase):
 
         room_b = self.create_local_room(
             self.user_b,
-            [],
             is_public=is_public,
         )
         assert room_b is not None, "Room should have been created"
@@ -233,7 +241,6 @@ class LocalProModeInviteTest(FederatingModuleApiTestCase):
         )
         room_c = self.create_local_room(
             self.user_c,
-            [],
             is_public=is_public,
         )
         assert room_c is not None, "Room should have been created"
@@ -249,7 +256,7 @@ class LocalProModeInviteTest(FederatingModuleApiTestCase):
 
     def test_invite_to_dm(self) -> None:
         """Tests that a dm with a local user can be created, but nobody else invited"""
-        room_id = self.create_local_room(self.user_a, [], is_public=False)
+        room_id = self.create_local_room(self.user_a, is_public=False)
         assert room_id, "Room not created"
 
         # create DM event
@@ -289,7 +296,7 @@ class LocalProModeInviteTest(FederatingModuleApiTestCase):
 
     def test_invite_to_group(self) -> None:
         """Tests that a group with local users works normally"""
-        room_id = self.create_local_room(self.user_a, [], is_public=False)
+        room_id = self.create_local_room(self.user_a, is_public=False)
         assert room_id, "Room not created"
 
         # create DM event
@@ -328,7 +335,7 @@ class LocalProModeInviteTest(FederatingModuleApiTestCase):
 
     def test_invite_to_group_without_dm_event(self) -> None:
         """Tests that a group with local users works normally in case the user has no m.direct set"""
-        room_id = self.create_local_room(self.user_a, [], is_public=False)
+        room_id = self.create_local_room(self.user_a, is_public=False)
         assert room_id, "Room not created"
 
         # Can invite other users
@@ -355,12 +362,22 @@ class LocalProModeInviteTest(FederatingModuleApiTestCase):
         )
 
 
+@parameterized_class(
+    ("DEFAULT_ROOM_VERSION",),
+    [
+        ("9",),
+        ("10",),
+        ("11",),
+        ("12",),
+    ],
+)
 class LocalEpaModeInviteTest(FederatingModuleApiTestCase):
     """
     These EPA server tests are for invites that happen after the room creation process
     has completed
     """
 
+    ALLOWED_ROOM_VERSIONS = ["9", "10", "11", "12"]
     server_name_for_this_server = INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
@@ -404,7 +421,6 @@ class LocalEpaModeInviteTest(FederatingModuleApiTestCase):
     ) -> None:
         room_id = self.create_local_room(
             self.user_e,
-            [],
             is_public=False,
         )
         assert room_id is not None, "Room should have been created"
@@ -446,7 +462,6 @@ class LocalEpaModeInviteTest(FederatingModuleApiTestCase):
     ) -> None:
         room_id = self.create_local_room(
             self.user_e,
-            [],
             is_public=False,
         )
         assert room_id is not None, "Room should have been created"
@@ -506,7 +521,6 @@ class LocalEpaModeInviteTest(FederatingModuleApiTestCase):
 
         room_e = self.create_local_room(
             self.user_e,
-            [],
             is_public=False,
         )
         assert room_e is not None, "Room should have been created"
@@ -521,7 +535,6 @@ class LocalEpaModeInviteTest(FederatingModuleApiTestCase):
         )
         room_f = self.create_local_room(
             self.user_f,
-            [],
             is_public=False,
         )
         assert room_f is not None, "Room should have been created"
@@ -537,7 +550,7 @@ class LocalEpaModeInviteTest(FederatingModuleApiTestCase):
 
     def test_invite_to_dm_post_room_creation(self) -> None:
         """Tests that a private room as a dm will deny inviting any local users"""
-        room_id = self.create_local_room(self.user_d, [], is_public=False)
+        room_id = self.create_local_room(self.user_d, is_public=False)
         assert room_id, "Room not created"
 
         # create DM event
@@ -570,7 +583,7 @@ class LocalEpaModeInviteTest(FederatingModuleApiTestCase):
 
     def test_invite_to_group_post_room_creation(self) -> None:
         """Tests that a private room for a group will deny inviting any local users, with an unrelated m.direct tag"""
-        room_id = self.create_local_room(self.user_d, [], is_public=False)
+        room_id = self.create_local_room(self.user_d, is_public=False)
         assert room_id, "Room not created"
 
         # create DM event
@@ -602,7 +615,7 @@ class LocalEpaModeInviteTest(FederatingModuleApiTestCase):
 
     def test_invite_to_group_without_dm_event_post_room_creation(self) -> None:
         """Tests that a group with local users is denied when the user has no m.direct set"""
-        room_id = self.create_local_room(self.user_d, [], is_public=False)
+        room_id = self.create_local_room(self.user_d, is_public=False)
         assert room_id, "Room not created"
 
         # Can't invite other users
@@ -622,10 +635,21 @@ class LocalEpaModeInviteTest(FederatingModuleApiTestCase):
         )
 
 
+@parameterized_class(
+    ("DEFAULT_ROOM_VERSION",),
+    [
+        ("9",),
+        ("10",),
+        ("11",),
+        ("12",),
+    ],
+)
 class DisabledDMCheckInviteTest(FederatingModuleApiTestCase):
     """
     This tests to make sure the DM check can be disabled
     """
+
+    ALLOWED_ROOM_VERSIONS = ["9", "10", "11", "12"]
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
         super().prepare(reactor, clock, homeserver)
@@ -650,7 +674,7 @@ class DisabledDMCheckInviteTest(FederatingModuleApiTestCase):
     def test_invite_to_dm(self) -> None:
         """Tests that a dm with a local user can be created, and others can be invited"""
         # This just copies the test from LocalProModeInviteTest but adjusts the expect_code to 200
-        room_id = self.create_local_room(self.user_a, [], is_public=False)
+        room_id = self.create_local_room(self.user_a, is_public=False)
         assert room_id, "Room not created"
 
         # create DM event

--- a/tests/test_local_joins.py
+++ b/tests/test_local_joins.py
@@ -16,6 +16,7 @@ import logging
 from http import HTTPStatus
 from typing import Any
 
+from parameterized import parameterized_class
 from synapse.server import HomeServer
 from synapse.util.clock import Clock
 from twisted.internet.testing import MemoryReactor
@@ -26,6 +27,15 @@ from tests.test_utils import INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL
 logger = logging.getLogger(__name__)
 
 
+@parameterized_class(
+    ("DEFAULT_ROOM_VERSION",),
+    [
+        ("9",),
+        ("10",),
+        ("11",),
+        ("12",),
+    ],
+)
 class LocalProJoinTestCase(FederatingModuleApiTestCase):
     """
     Tests to verify that we don't break local public/private rooms by accident.
@@ -34,6 +44,7 @@ class LocalProJoinTestCase(FederatingModuleApiTestCase):
     need this test, as they do not allow for local joining.
     """
 
+    ALLOWED_ROOM_VERSIONS = ["9", "10", "11", "12"]
     # server_name_for_this_server = "tim.test.gematik.de"
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
@@ -58,7 +69,7 @@ class LocalProJoinTestCase(FederatingModuleApiTestCase):
 
     def test_joining_public_with_invites(self) -> None:
         """Test joining a local public room with invites is allowed"""
-        room_id = self.create_local_room(self.user_a, [], is_public=True)
+        room_id = self.create_local_room(self.user_a, is_public=True)
         assert room_id is not None, "Room should have been created"
 
         self.helper.invite(room_id, self.user_a, self.user_b, tok=self.access_token_a)
@@ -66,14 +77,14 @@ class LocalProJoinTestCase(FederatingModuleApiTestCase):
 
     def test_joining_public_no_invites(self) -> None:
         """Test joining a local public room with no invites is allowed"""
-        room_id = self.create_local_room(self.user_a, [], is_public=True)
+        room_id = self.create_local_room(self.user_a, is_public=True)
         assert room_id is not None, "Room should have been created"
 
         self.helper.join(room_id, self.user_b, tok=self.access_token_b)
 
     def test_rejoining_public_no_invites(self) -> None:
         """Test re-joining a local public room with no invites is allowed"""
-        room_id = self.create_local_room(self.user_a, [], is_public=True)
+        room_id = self.create_local_room(self.user_a, is_public=True)
         assert room_id is not None, "Room should have been created"
 
         self.helper.join(room_id, self.user_b, tok=self.access_token_b)
@@ -84,7 +95,7 @@ class LocalProJoinTestCase(FederatingModuleApiTestCase):
 
     def test_joining_private_no_invites(self) -> None:
         """Test joining a local private room with no invites is denied"""
-        room_id = self.create_local_room(self.user_a, [], is_public=False)
+        room_id = self.create_local_room(self.user_a, is_public=False)
         assert room_id is not None, "Room should have been created"
 
         self.helper.join(
@@ -96,7 +107,7 @@ class LocalProJoinTestCase(FederatingModuleApiTestCase):
 
     def test_joining_private_with_invites(self) -> None:
         """Test joining a local private room with invites is allowed"""
-        room_id = self.create_local_room(self.user_a, [], is_public=False)
+        room_id = self.create_local_room(self.user_a, is_public=False)
         assert room_id is not None, "Room should have been created"
 
         self.helper.invite(room_id, self.user_a, self.user_b, tok=self.access_token_a)
@@ -104,7 +115,7 @@ class LocalProJoinTestCase(FederatingModuleApiTestCase):
 
     def test_rejoining_private_with_invites(self) -> None:
         """Test re-joining a local private room with initial invites forbidden"""
-        room_id = self.create_local_room(self.user_a, [], is_public=False)
+        room_id = self.create_local_room(self.user_a, is_public=False)
         assert room_id is not None, "Room should have been created"
 
         self.helper.invite(room_id, self.user_a, self.user_b, tok=self.access_token_a)
@@ -120,12 +131,22 @@ class LocalProJoinTestCase(FederatingModuleApiTestCase):
         )
 
 
+@parameterized_class(
+    ("DEFAULT_ROOM_VERSION",),
+    [
+        ("9",),
+        ("10",),
+        ("11",),
+        ("12",),
+    ],
+)
 class LocalEpaJoinTestCase(FederatingModuleApiTestCase):
     """
     Tests to verify that we don't break local public/private rooms behavior by accident.
     Specifically, this checks the code for joining a room and not just inviting
     """
 
+    ALLOWED_ROOM_VERSIONS = ["9", "10", "11", "12"]
     server_name_for_this_server = INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
@@ -154,7 +175,7 @@ class LocalEpaJoinTestCase(FederatingModuleApiTestCase):
 
         See comments below for thoughts on why
         """
-        room_id = self.create_local_room(self.user_a, [], is_public=True)
+        room_id = self.create_local_room(self.user_a, is_public=True)
         # Public rooms don't exist, so it should be "None" here. Rather hard to invite
         # and join a room without a room ID
         assert room_id is None, "Room should not have been created"
@@ -175,7 +196,7 @@ class LocalEpaJoinTestCase(FederatingModuleApiTestCase):
 
     def test_joining_private_no_invites(self) -> None:
         """Test joining a local private room with no invites is denied"""
-        room_id = self.create_local_room(self.user_a, [], is_public=False)
+        room_id = self.create_local_room(self.user_a, is_public=False)
         assert room_id is not None, "Room should have been created"
 
         self.helper.join(
@@ -187,7 +208,7 @@ class LocalEpaJoinTestCase(FederatingModuleApiTestCase):
 
     def test_joining_private_with_invites(self) -> None:
         """Test joining a local private room with invites is denied"""
-        room_id = self.create_local_room(self.user_a, [], is_public=False)
+        room_id = self.create_local_room(self.user_a, is_public=False)
         assert room_id is not None, "Room should have been created"
 
         self.helper.invite(

--- a/tests/test_reactions.py
+++ b/tests/test_reactions.py
@@ -63,7 +63,7 @@ class ReactionLimitationTestCase(FederatingModuleApiTestCase):
         return conf
 
     def test_single_cluster_reaction(self) -> None:
-        room_id = self.create_local_room(self.user_a, [], False)
+        room_id = self.create_local_room(self.user_a, is_public=False)
         assert room_id is not None
         message_1_body = self.helper.send(
             room_id, "message 1", tok=self.map_user_id_to_token[self.user_a]
@@ -164,7 +164,7 @@ class ReactionLimitationTestCase(FederatingModuleApiTestCase):
         )
 
     def test_empty_reaction(self) -> None:
-        room_id = self.create_local_room(self.user_a, [], False)
+        room_id = self.create_local_room(self.user_a, is_public=False)
         assert room_id is not None
         message_1_body = self.helper.send(
             room_id, "message 1", tok=self.map_user_id_to_token[self.user_a]
@@ -185,7 +185,7 @@ class ReactionLimitationTestCase(FederatingModuleApiTestCase):
         )
 
     def test_multiple_cluster_reaction(self) -> None:
-        room_id = self.create_local_room(self.user_a, [], False)
+        room_id = self.create_local_room(self.user_a, is_public=False)
         assert room_id is not None
         message_1_body = self.helper.send(
             room_id, "message 1", tok=self.map_user_id_to_token[self.user_a]

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -15,6 +15,7 @@
 import logging
 from http import HTTPStatus
 
+from parameterized import parameterized_class
 from synapse.server import HomeServer
 from synapse.util.clock import Clock
 from twisted.internet.testing import MemoryReactor
@@ -46,12 +47,22 @@ def _redact_event_helper(
     return channel.json_body
 
 
+@parameterized_class(
+    ("DEFAULT_ROOM_VERSION",),
+    [
+        ("9",),
+        ("10",),
+        ("11",),
+        ("12",),
+    ],
+)
 class RedactionTimeLimitTestCase(FederatingModuleApiTestCase):
     """
     Test that redactions of events older than 24 hours are rejected in TIM version 1.2.
     """
 
     TIM_VERSION = TimVersion.V1_2
+    ALLOWED_ROOM_VERSIONS = ["9", "10", "11", "12"]
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
         super().prepare(reactor, clock, homeserver)
@@ -72,7 +83,7 @@ class RedactionTimeLimitTestCase(FederatingModuleApiTestCase):
         )
 
     def test_redaction_within_24h_allowed(self) -> None:
-        room_id = self.create_local_room(self.user_a, [], False)
+        room_id = self.create_local_room(self.user_a, is_public=False)
         assert room_id is not None
 
         body = self.helper.send(
@@ -89,7 +100,7 @@ class RedactionTimeLimitTestCase(FederatingModuleApiTestCase):
         )
 
     def test_redaction_after_24h_rejected(self) -> None:
-        room_id = self.create_local_room(self.user_a, [], False)
+        room_id = self.create_local_room(self.user_a, is_public=False)
         assert room_id is not None
 
         body = self.helper.send(
@@ -109,7 +120,7 @@ class RedactionTimeLimitTestCase(FederatingModuleApiTestCase):
         )
 
     def test_redaction_after_24h_allowed_for_admin(self) -> None:
-        room_id = self.create_local_room(self.admin_user, [], False)
+        room_id = self.create_local_room(self.admin_user, is_public=False)
         assert room_id is not None
 
         body = self.helper.send(
@@ -129,12 +140,22 @@ class RedactionTimeLimitTestCase(FederatingModuleApiTestCase):
         )
 
 
+@parameterized_class(
+    ("DEFAULT_ROOM_VERSION",),
+    [
+        ("9",),
+        ("10",),
+        ("11",),
+        ("12",),
+    ],
+)
 class RedactionTimeLimitV1_1TestCase(FederatingModuleApiTestCase):
     """
     Test that redactions are NOT restricted by time in TIM version 1.1.
     """
 
     TIM_VERSION = TimVersion.V1_1
+    ALLOWED_ROOM_VERSIONS = ["9", "10", "11", "12"]
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
         super().prepare(reactor, clock, homeserver)
@@ -153,7 +174,7 @@ class RedactionTimeLimitV1_1TestCase(FederatingModuleApiTestCase):
         )
 
     def test_redaction_after_24h_allowed_in_v1_1(self) -> None:
-        room_id = self.create_local_room(self.user_a, [], False)
+        room_id = self.create_local_room(self.user_a, is_public=False)
         assert room_id is not None
 
         body = self.helper.send(

--- a/tests/test_remote_joins.py
+++ b/tests/test_remote_joins.py
@@ -81,7 +81,7 @@ class IncomingRemoteJoinTestCase(FederatingModuleApiTestCase):
         Test _with no invites_ behavior for public and private rooms when there is an
         incoming remote user
         """
-        room_id = self.create_local_room(self.user_a, [], is_public=is_public)
+        room_id = self.create_local_room(self.user_a, is_public=is_public)
         assert room_id is not None, "Room should have been created"
 
         # public should not succeed
@@ -100,7 +100,7 @@ class IncomingRemoteJoinTestCase(FederatingModuleApiTestCase):
         incoming remote user
         """
         # Try with user "d", make a fresh room
-        room_id = self.create_local_room(self.user_d, [], is_public=is_public)
+        room_id = self.create_local_room(self.user_d, is_public=is_public)
         assert room_id is not None, "Room should have been created"
 
         # for a public room this should fail
@@ -129,7 +129,7 @@ class IncomingRemoteJoinTestCase(FederatingModuleApiTestCase):
         Test with no invites behavior for public and private rooms when there is an
         incoming remote user
         """
-        room_id = self.create_local_room(self.user_a, [], is_public=is_public)
+        room_id = self.create_local_room(self.user_a, is_public=is_public)
         assert room_id is not None, "Room should have been created"
 
         # public should not succeed
@@ -147,7 +147,7 @@ class IncomingRemoteJoinTestCase(FederatingModuleApiTestCase):
         Test with invites behavior for public and private rooms when there is an
         incoming remote user
         """
-        room_id = self.create_local_room(self.user_a, [], is_public=is_public)
+        room_id = self.create_local_room(self.user_a, is_public=is_public)
         assert room_id is not None, "Room should have been created"
 
         # Private rooms, this should be allowed without permission
@@ -217,7 +217,7 @@ class DisableOverridePublicRoomFederationTestCase(FederatingModuleApiTestCase):
         Test that the local server can successfully allow joining a remote room when
         there are no invites
         """
-        room_id = self.create_local_room(self.user_a, [], is_public=True)
+        room_id = self.create_local_room(self.user_a, is_public=True)
         assert room_id is not None, "Room should have been created"
 
         # make_join should succeed, as the override was blocked

--- a/tests/test_room_message_timestamp.py
+++ b/tests/test_room_message_timestamp.py
@@ -58,7 +58,7 @@ class MessageTimestampTestCase(FederatingModuleApiTestCase):
 
             assert event_ts == ts_found
 
-        room_id = self.create_local_room(self.user_a, [], is_public=False)
+        room_id = self.create_local_room(self.user_a, is_public=False)
         assert room_id, "Room created"
 
         self.helper.invite(room_id, targ=self.user_b, tok=self.access_token_a)

--- a/tests/test_room_versions.py
+++ b/tests/test_room_versions.py
@@ -13,21 +13,73 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 from http import HTTPStatus
+from typing import Any
 
-from parameterized import parameterized
+from parameterized import parameterized, parameterized_class
 from synapse.server import HomeServer
 from synapse.util.clock import Clock
 from twisted.internet.testing import MemoryReactor
 
-from tests.base import FederatingModuleApiTestCase, construct_extra_content
+from tests.base import FederatingModuleApiTestCase
 from tests.server import make_request
 
 
+@parameterized_class(
+    (
+        "DEFAULT_ROOM_VERSION",
+        "ALLOWED_ROOM_VERSIONS",
+        "ROOM_VERSIONS_THAT_SHOULD_FAIL",
+        "ROOM_UPGRADE_AND_DOWNGRADE_PAIRINGS",
+        "ROOM_UPGRADE_AND_DOWNGRADE_FAILURES",
+    ),
+    [
+        (
+            "9",
+            ["9", "10"],
+            ["8", 11, "bad_version"],
+            [("9", "10"), ("10", "9")],
+            ["8", "11"],
+        ),
+        (
+            "10",
+            ["10", "11"],
+            ["9", "not_real", 9],
+            [("10", "11"), ("11", "10")],
+            ["9", "12"],
+        ),
+        (
+            "11",
+            ["11", "12"],
+            ["10", "should_fail"],
+            [("11", "12"), ("12", "11")],
+            ["10"],
+        ),
+        (
+            "12",
+            ["11", "12"],
+            ["9", 1, ["bad_version"]],
+            [("11", "12"), ("12", "11")],
+            ["10"],
+        ),
+    ],
+)
 class RoomVersionCreateRoomTest(FederatingModuleApiTestCase):
     """
-    Tests for limiting room versions when creating rooms. Use the defaults of room
-    versions "9" or "10"
+    Tests for limiting room versions when upgrading and downgrading rooms.
     """
+
+    # This is defined through the parameterize_class
+    # ALLOWED_ROOM_VERSIONS
+    # One test function checks these iteratively for failure. All should BAD_REQUEST
+    ROOM_VERSIONS_THAT_SHOULD_FAIL: list[Any]
+    # Tuples of pairings of room versions used to verify upgrades and downgrades. Going
+    # either direction should work as long as both are inside the ALLOWED_ROOM_VERSIONS
+    # limits.
+    # (start version, end version)
+    ROOM_UPGRADE_AND_DOWNGRADE_PAIRINGS: list[tuple[str, str]]
+    # A list of upgrades or downgrades that should fall outside the limits defined by
+    # ALLOWED_ROOM_VERSIONS. These should all fail. Test starts with default room ver.
+    ROOM_UPGRADE_AND_DOWNGRADE_FAILURES: list[str]
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer):
         super().prepare(reactor, clock, homeserver)
@@ -37,31 +89,6 @@ class RoomVersionCreateRoomTest(FederatingModuleApiTestCase):
 
         self.admin_b = self.register_user("b", "password", admin=True)
         self.access_token_b = self.login("b", "password")
-
-    def user_create_room(
-        self,
-        is_public: bool = False,
-        room_ver: str | None = None,
-        expect_code: int = HTTPStatus.OK,
-    ) -> str | None:
-        """
-        Helper to send an api request with a full set of required additional room state
-        to the room creation matrix endpoint. Returns a room_id if successful.
-
-        This differs from the create_local_room() helper, as it allows to designate
-        the room version and the expected response code. It also will subvert the
-        invitee_list, as it is not useful when determining if the room would be created.
-        """
-        # Hide the assertion from create_room_as() when the error code is unexpected. It
-        # makes errors for the tests less clear when all we get is the http response
-        return self.helper.create_room_as(
-            self.user_a,
-            is_public=is_public,
-            room_version=room_ver,
-            tok=self.access_token_a,
-            expect_code=expect_code,
-            extra_content=construct_extra_content(self.user_a, []),
-        )
 
     def upgrade_room_to_version(
         self,
@@ -97,94 +124,86 @@ class RoomVersionCreateRoomTest(FederatingModuleApiTestCase):
     def test_create_room_fails(self, _label: str, is_public: bool) -> None:
         """
         Test that most generic ways of not doing a room version string, and a room
-        version that is outside of what is wanted, fail
+        version that is outside what is allowed, fail
         """
-        self.user_create_room(
-            is_public=is_public,
-            room_ver="8",
-            expect_code=HTTPStatus.BAD_REQUEST,
-        )
-
-        self.user_create_room(
-            is_public=is_public,
-            room_ver=8,  # type: ignore[arg-type]
-            expect_code=HTTPStatus.BAD_REQUEST,
-        )
-
-        self.user_create_room(
-            is_public=is_public,
-            room_ver="11",
-            expect_code=HTTPStatus.BAD_REQUEST,
-        )
-
-        self.user_create_room(
-            is_public=is_public,
-            room_ver=11,  # type: ignore[arg-type]
-            expect_code=HTTPStatus.BAD_REQUEST,
-        )
-
-        self.user_create_room(
-            is_public=is_public,
-            room_ver="bad_version",
-            expect_code=HTTPStatus.BAD_REQUEST,
-        )
+        for room_version in self.ROOM_VERSIONS_THAT_SHOULD_FAIL:
+            room_id = self.create_local_room(
+                self.user_a,
+                is_public=is_public,
+                room_version=room_version,
+                expected_code=HTTPStatus.BAD_REQUEST,
+            )
+            assert room_id is None
 
     @parameterized.expand([("public", True), ("private", False)])
     def test_create_room_succeeds(self, _label: str, is_public: bool) -> None:
         """
-        Tests that a room version that is allowed succeeds
+        Tests that a room version that is allowed succeeds. This will use the default
+        room version since they are all itemized per the parameterize_class
         """
-        self.user_create_room(
+        room_id = self.create_local_room(
+            self.user_a,
             is_public=is_public,
-            room_ver="9",
-            expect_code=HTTPStatus.OK,
+            expected_code=HTTPStatus.OK,
         )
-        self.user_create_room(
-            is_public=is_public,
-            room_ver="10",
-            expect_code=HTTPStatus.OK,
-        )
+        assert room_id is not None
 
     @parameterized.expand([("public", True), ("private", False)])
-    def test_room_upgrades(self, _label: str, is_public: bool) -> None:
+    def test_room_upgrades_and_downgrades(self, _label: str, is_public: bool) -> None:
         """
-        Test room upgrades fail outside of defaults
+        Test room upgrades and downgrades work inside of limits, including "upgrading"
+        to the same room version
         """
-        # 9 -> 9 works
-        room_id = self.user_create_room(is_public=is_public, room_ver="9")
-        assert room_id
-        room_id = self.upgrade_room_to_version(room_id, "9", self.access_token_a)
-        assert room_id
+        for (
+            start_room_version,
+            finish_room_version,
+        ) in self.ROOM_UPGRADE_AND_DOWNGRADE_PAIRINGS:
 
-        # 10 -> 10 works
-        room_id = self.user_create_room(is_public=is_public, room_ver="10")
-        assert room_id
-        room_id = self.upgrade_room_to_version(room_id, "10", self.access_token_a)
-        assert room_id
+            # First test that a room can be "upgraded" into the same room version
+            room_id = self.create_local_room(
+                self.user_a, is_public=is_public, room_version=start_room_version
+            )
+            assert room_id is not None
+            room_id = self.upgrade_room_to_version(
+                room_id, start_room_version, self.access_token_a
+            )
+            assert room_id is not None
 
-        # 9 -> 10 works
-        room_id = self.user_create_room(is_public=is_public, room_ver="9")
-        assert room_id
-        room_id = self.upgrade_room_to_version(room_id, "10", self.access_token_a)
-        assert room_id
+            # Then test that a real version change works
+            room_id = self.create_local_room(
+                self.user_a, is_public=is_public, room_version=start_room_version
+            )
+            assert room_id is not None
+            room_id = self.upgrade_room_to_version(
+                room_id, finish_room_version, self.access_token_a
+            )
+            assert room_id is not None
 
-        # 9 -> 8 doesn't work
-        room_id = self.user_create_room(is_public=is_public, room_ver="9")
-        assert room_id
+    @parameterized.expand([("public", True), ("private", False)])
+    def test_room_version_fails_outside_of_allowed_limits(
+        self, _label: str, is_public: bool
+    ) -> None:
+        """
+        Test that changing a room version outside the limits fails, but works for an
+        admin. Each room starts with the DEFAULT_ROOM_VERSION
+        """
+        for change_room_version_to in self.ROOM_UPGRADE_AND_DOWNGRADE_FAILURES:
+            # First test that the "downgrade" fails with normal user
+            # This is a DEFAULT_ROOM_VERSION room
+            room_id = self.create_local_room(self.user_a, is_public=is_public)
+            assert room_id is not None
 
-        room_id = self.upgrade_room_to_version(room_id, "8", self.access_token_a)
-        assert room_id is None
+            room_id = self.upgrade_room_to_version(
+                room_id, change_room_version_to, self.access_token_a
+            )
+            # This is None because the room should fail
+            assert room_id is None
 
-        # 9 -> 8 requires an admin
-        room_id = self.helper.create_room_as(
-            self.admin_b,
-            is_public=is_public,
-            room_version="9",
-            tok=self.access_token_b,
-            expect_code=200,
-            extra_content=construct_extra_content(self.admin_b, []),
-        )
-        assert room_id
+            # Then make sure it works with an admin. This is a DEFAULT_ROOM_VERSION room
+            room_id = self.create_local_room(self.admin_b, is_public=is_public)
+            assert room_id is not None
 
-        room_id = self.upgrade_room_to_version(room_id, "8", self.access_token_b)
-        assert room_id
+            room_id = self.upgrade_room_to_version(
+                room_id, change_room_version_to, self.access_token_b
+            )
+            assert room_id is not None

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -16,7 +16,7 @@
 from typing import Any
 
 import pytest
-from parameterized import parameterized
+from parameterized import parameterized, parameterized_class
 from synapse.api.constants import EventTypes, JoinRules, Membership
 from synapse.api.errors import AuthError
 from synapse.api.room_versions import KNOWN_ROOM_VERSIONS
@@ -37,6 +37,15 @@ from tests.test_utils import (
 )
 
 
+@parameterized_class(
+    ("DEFAULT_ROOM_VERSION",),
+    [
+        ("9",),
+        ("10",),
+        ("11",),
+        ("12",),
+    ],
+)
 class InsuredOnlyRoomScanTaskTestCase(FederatingModuleApiTestCase):
     """
     Test that insured only room scans are done, and required room kicks are done
@@ -51,6 +60,7 @@ class InsuredOnlyRoomScanTaskTestCase(FederatingModuleApiTestCase):
     server_name_for_this_server = INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL
     # The default "fake" remote server name that has its server signing keys auto-injected
     OTHER_SERVER_NAME = DOMAIN_IN_LIST
+    ALLOWED_ROOM_VERSIONS = ["9", "10", "11", "12"]
 
     def default_config(self) -> dict[str, Any]:
         conf = super().default_config()
@@ -113,7 +123,7 @@ class InsuredOnlyRoomScanTaskTestCase(FederatingModuleApiTestCase):
         rooms) and rooms with no invites at all.
         """
         # Make a room...
-        room_id = self.create_local_room(self.user_d, [], is_public=False)
+        room_id = self.create_local_room(self.user_d, is_public=False)
         assert room_id is not None, "Room should be created"
 
         # ...then (maybe) invite the doctor
@@ -264,7 +274,7 @@ class InsuredOnlyRoomScanTaskTestCase(FederatingModuleApiTestCase):
         """
         # Make a room and invite the doctor
         room_id = self.create_local_room(
-            self.user_d, [self.remote_pro_user], is_public=False
+            self.user_d, is_public=False, invitee_list=[self.remote_pro_user]
         )
         assert room_id is not None
 
@@ -412,7 +422,7 @@ class InsuredOnlyRoomScanTaskTestCase(FederatingModuleApiTestCase):
         Test that a room is not detected as inactive if one of two doctors never show up
         """
         # Make a room and invite the doctor
-        room_id = self.create_local_room(self.user_d, [], is_public=False)
+        room_id = self.create_local_room(self.user_d, is_public=False)
         assert room_id is not None
 
         is_room_blocked = self.get_success_or_raise(self.store.is_room_blocked(room_id))
@@ -464,6 +474,15 @@ class InsuredOnlyRoomScanTaskTestCase(FederatingModuleApiTestCase):
             self.create_and_send_event(room_id, self.user_d_id)
 
 
+@parameterized_class(
+    ("DEFAULT_ROOM_VERSION",),
+    [
+        ("9",),
+        ("10",),
+        ("11",),
+        ("12",),
+    ],
+)
 class InsuredOnlyRoomScanIgnoreInvitesTaskTestCase(FederatingModuleApiTestCase):
     """
     Test that insured only room scans are done, and required room kicks are done. Unlike
@@ -477,6 +496,7 @@ class InsuredOnlyRoomScanIgnoreInvitesTaskTestCase(FederatingModuleApiTestCase):
     server_name_for_this_server = INSURANCE_DOMAIN_IN_LIST_FOR_LOCAL
     # The default "fake" remote server name that has its server signing keys auto-injected
     OTHER_SERVER_NAME = DOMAIN_IN_LIST
+    ALLOWED_ROOM_VERSIONS = ["9", "10", "11", "12"]
 
     def default_config(self) -> dict[str, Any]:
         conf = super().default_config()
@@ -518,7 +538,7 @@ class InsuredOnlyRoomScanIgnoreInvitesTaskTestCase(FederatingModuleApiTestCase):
         """
         # Make a room and invite the doctor
         room_id = self.create_local_room(
-            self.user_d, [self.remote_pro_user], is_public=False
+            self.user_d, is_public=False, invitee_list=[self.remote_pro_user]
         )
         assert room_id is not None, "Room should be created"
 
@@ -753,7 +773,7 @@ class InactiveRoomScanTaskV1_1TestCase(FederatingModuleApiTestCase):
         a room for "inactive_room_scan.grace_period" amount of time
         """
         # Make a room and invite the other occupant(s)
-        room_id = self.create_local_room(self.user_a, [], is_public=is_public)
+        room_id = self.create_local_room(self.user_a, is_public=is_public)
         assert room_id is not None, "Room should exist"
 
         for other_user in other_users:
@@ -1221,7 +1241,7 @@ class StateOnlyPurgeRoomScanTaskV1_2TestCase(FederatingModuleApiTestCase):
         )
 
         # Make a room and invite the other occupant(s)
-        room_id = self.create_local_room(self.user_a, [], is_public=is_public)
+        room_id = self.create_local_room(self.user_a, is_public=is_public)
         assert room_id is not None, "Room should exist"
 
         for other_user in other_users:


### PR DESCRIPTION
SYN-31

Refactor a bunch of tests to be parameterized and check previous and newer room versions. This does have the "less-than-nice" effect of multiplying the number of tests ran

Because the `FakeRoom` does not support room version "11" and "12" yet, this does not touch:
* `OutgoingEPARemoteJoinTestCase`
* `OutgoingPRORemoteJoinTestCase`
* `InactiveRoomScanTaskV1_1TestCase`
* `StateOnlyPurgeRoomScanTaskV1_2TestCase`

These an be handled in a follow-up work, as that is more invasive and this was large enough to look at.

May be best reviewed commit-by-commit