### PR TITLE
chore: Rework testing to reduce time spent and to remove the `hatch run cov` command

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,10 +24,12 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        database: ["sqlite", "postgres"]
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
+        id: setup-python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -62,10 +64,16 @@ jobs:
           args: check --target-version ${{ env.PYTHON_TARGET }}
 
       - name: Tests and coverage
-        run: hatch run cov
+        shell: bash
+        run: hatch test --python ${{ matrix.python-version }} -p -c
         env:
-          # to ensure we run ci:cov instead of default:cov, where the former generates more coverage files
-          HATCH_ENV: "ci"
+          # These two options can always be populated, as unless the third below
+          # is also enabled they are just ignored.
+          SYNAPSE_POSTGRES_USER: "postgres"
+          SYNAPSE_POSTGRES_PASSWORD: "postgres"
+          # Although the options are 'postgres' and 'sqlite', we only populate this when
+          # it is 'postgres'
+          SYNAPSE_POSTGRES: ${{ matrix.database == 'postgres' || ''}}
 
       - name: Codecov - Upload coverage
         uses: codecov/codecov-action@v4

--- a/README.md
+++ b/README.md
@@ -109,12 +109,26 @@ To create virtual env and install dependency:
 hatch shell
 ```
 
-The tests uses twisted's testing framework trial, with the development
-environment managed by hatch. Running the tests and generating a coverage report
-can be done like this:
+The tests uses pytest, with the development environment managed by hatch. Running the tests can be done like this:
 
 ```console
-hatch run cov
+hatch test
+```
+
+#### Additional optional testing arguments:
+Run the tests in parallel: `-p`
+
+Collect coverage data(automatically output as `lcov.info`): `-c`
+
+#### Running a specific test:
+Selecting a specific test to run can be as easy as providing the path to the test. All tests start from
+the base test directory, `tests`. If running all tests, this can be left out. If requiring only tests
+from `test_createrooms_local.py`, append `tests/test_createrooms_local.py` to the command, and all tests
+in that file will run. If requiring only tests in `LocalProModeCreateRoomTest`, appending
+`tests/test_createrooms_local.py::LocalProModeCreateRoomTest` to the command will run only those tests.
+As an example of running only the test for checking that the default state of the history visibility for a room is "invited":
+```console
+hatch test tests/test_createrooms_local.py::LocalProModeCreateRoomTest::test_create_room_default_history_visibility_invited
 ```
 
 ## Code Quality

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "synapse-invite-checker"
 description = 'Synapse module to handle TIM contact management and invite permissions'
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 license = "AGPL-3.0-only"
 keywords = []
 authors = [
@@ -15,8 +15,10 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -83,27 +85,16 @@ lint-fix = [
   "ruff check --fix"
 ]
 
-[tool.hatch.envs.default.scripts]
-cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=synapse_invite_checker --cov=tests"
-
-# For CI use
-[tool.hatch.envs.ci.scripts]
-cov = "pytest --cov-report=lcov:lcov.info --cov-report=xml --cov-report=term-missing --cov-config=pyproject.toml --cov=synapse_invite_checker --cov=tests"
-
-[[tool.hatch.envs.ci.matrix]]
-database = [ "postgres", "sqlite"]
-
-[tool.hatch.envs.ci.overrides]
-matrix.database.env-vars = [
-  { key = "SYNAPSE_POSTGRES", value = "1", if = ["postgres"] },
-  { key = "SYNAPSE_POSTGRES_USER", value = "postgres", if = ["postgres"] },
-  { key = "SYNAPSE_POSTGRES_PASSWORD", value = "postgres", if = ["postgres"] },
-]
-
 [tool.coverage.run]
 branch = true
 parallel = true
-omit = ["tests/*"]
+
+[tool.coverage.report]
+exclude_lines = [
+  "no cov",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+]
 
 [tool.ruff]
 target-version = "py310"
@@ -123,13 +114,6 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101", "S105", "PLR2004", "N803", "SLF001", "UP035", "PT019"]
 
-[tool.coverage.report]
-exclude_lines = [
-  "no cov",
-  "if __name__ == .__main__.:",
-  "if TYPE_CHECKING:",
-]
-
 [tool.mypy]
 python_version = "3.10"
 ignore_missing_imports = true
@@ -143,3 +127,48 @@ files = ["synapse_invite_checker", "tests"]
 [tool.isort]
 profile = "black"
 src_paths = ["synapse_invite_checker", "tests"]
+
+[tool.hatch.envs.hatch-test]
+# The Hatch test environment includes the default pytest, mock and coverage
+# dependencies. If you should need additional, use the 'extra-dependencies' section
+# below.
+extra-dependencies = [
+  "parameterized",
+  "psycopg2",
+  "pytest-cov",
+  # we don't depend on synapse directly to prevent pip from pulling the wrong synapse,
+  # when we just want to install the module
+  "matrix-synapse @ git+https://github.com/famedly/synapse.git@master"
+]
+
+# The 'hatch test ...' command has the built-in scripts that define its invocation.
+# Override these scripts so coverage works as expected.
+#
+# In particular, the 'coverage run -m pytest ...' command does not work correctly.
+# In CI, it was not producing the subprocess-enabled coverage files, even though it
+# worked locally (there should have been 4 files, but only 1 was produced, and it had
+# no data). Using the pytest-cov plugin does seem to produce these files, and the
+# missing-lines display format is also correct. Since it handles the internal
+# combine/report commands, set those scripts below to do nothing (or CI will report
+# fake errors).
+[tool.hatch.envs.hatch-test.scripts]
+# The HATCH_TEST_ARGS environment variable is how the `test` command's flags are
+# translated and internally populated without affecting the user's arguments. This is
+# also the way that "extra arguments" are passed. Leave it there
+run = "pytest{env:HATCH_TEST_ARGS:} {args}"
+# The original 'run-cov' is below; this is overridden to produce coverage properly.
+#run-cov = "coverage run -m pytest{env:HATCH_TEST_ARGS:} {args}"
+# Notes for this command line: using --cov=synapse_invite_checker instead of having
+# that directory in the 'coverage.run' config above actually produces the correct
+# coverage files (the ones that were missing, as mentioned above). The 'cov-report'
+# options both produce useful output (one for the codecov file and the other displays
+# the missing coverage lines).
+run-cov = "pytest{env:HATCH_TEST_ARGS:} --cov=synapse_invite_checker --cov-report=lcov:lcov.info --cov-report=term-missing --cov-config=pyproject.toml {args}"
+
+# As mentioned above, the defaults for these scripts are commented out as they will
+# produce fake errors in CI. They attempt to run but the result of those commands
+# already exists. This raises error codes and fails the test.
+#cov-combine = "coverage combine"
+#cov-report = "coverage report"
+cov-combine = ""
+cov-report = ""


### PR DESCRIPTION
Tests were taking to long. Let's speed them up!

Before, we ran unit tests and collected coverage with the command `hatch run cov`. This ran the tests on a single process/thread and (in CI) tested against both SQLite and Postgres as a matrix, consecutively.

Now, the built-in `hatch test` command can be used for the same purpose.
`hatch test` will run all tests without coverage on a single process/thread
Add `-p` as an option to run all tests using all available cores/threads of a CPU.
Add `-c` as an option to collect coverage data.

These are interchangeable. Previously, on my machine these tests with coverage took just over 2 minutes, now it is just over 30 seconds. Without coverage is even faster.

SQLite testing will be the default. Running in Postgres is only slightly more labor intensive. A Postgres installation is required of course(see the `python.yml` testing workflow for a quick example) and then add to the front of your command the ENV variables that the testing suite will automatically look for:
`SYNAPSE_POSTGRES=1 SYNAPSE_POSTGRES_USER=<theDatabaseUser> SYNAPSE_POSTGRES_PASSWORD=<theDBUsersPassword> hatch test`