### PR TITLE
chore: use uv as the dependencies installer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ Issues = "https://github.com/famedly/synapse-invite-checker/-/issues"
 Source = "https://github.com/famedly/synapse-invite-checker/"
 
 [tool.hatch.envs.default]
+installer = "uv"
 dependencies = [
   "black",
   "pytest",


### PR DESCRIPTION
but keep using hatch for everything else since we get most of uv's benefits on the dependencies installation step and its other benefits are not worth enough for the change