### PR TITLE
chore!: Prohibit history visibility of `world_readable` if a room is allowed to federate

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ modules:
           enabled: true or false  # optional switch to disable the room scan for state only rooms, defaults to true if TIM version is set to "1.2" (or newer)
           grace_period: see 'Duration Parsing' below #  Length of time a room is allowed to have no non-state/timeline activity(such as a message) before it is eligible for deletion. Ignored if 'enabled' is false. Defaults to "6w" which is 6 weeks
         override_public_room_federation: true or false, # Forces the `m.federate` flag to be set to False when creating a public room to prevent it from federating. Default is "true", disable with "false"
-        prohibit_world_readable_rooms: true or false, # Prevent setting any rooms history visibility as 'world_readable'. Defaults to "true"
+        prohibit_world_readable_rooms: true or false, # Prevent setting any rooms history visibility as 'world_readable'. Defaults to "false"
         block_invites_into_dms: true or false, # Prevent invites into existing DM chats. Defaults to true
         limit_reactions: true or false, # Prevent more than a single grapheme cluster in a reaction. Defaults to true, false to disable
         disable_epa_communication: true or false, # Explicitly block all invites and joins to/from ePA domains. Logs a warning at startup when enabled. Defaults to false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
 dependencies = [
   "black",
   "isort",
-  "ruff",
+  "ruff==0.15.22",
   "mypy",
   "mypy-zope",
   "pydantic",

--- a/synapse_invite_checker/config.py
+++ b/synapse_invite_checker/config.py
@@ -60,7 +60,7 @@ class InviteCheckerConfig:
         default_factory=StateOnlyRoomPurgeConfig
     )
     override_public_room_federation: bool = True
-    prohibit_world_readable_rooms: bool = True
+    prohibit_world_readable_rooms: bool = False
     block_invites_into_dms: bool = True
     limit_reactions: bool = True
     redaction_max_age_ms: int = 24 * 60 * 60 * 1000

--- a/synapse_invite_checker/invite_checker.py
+++ b/synapse_invite_checker/invite_checker.py
@@ -908,33 +908,32 @@ class InviteChecker:
                 )
             # PRO: only being "public" on PRO if "m.federate" is set to True in the creation event
             elif self.config.tim_type == TimType.PRO and join_rule == JoinRules.PUBLIC:
-                creation_event = context.get((EventTypes.Create, ""))
-                # `m.federate` defaults to True if unspecified
-                federated_flag = True
-                if creation_event and creation_event["content"]:
-                    federated_flag = creation_event["content"].get(
-                        EventContentFields.FEDERATE, True
-                    )
                 # Remember to account for the override disabler
-                if federated_flag and self.config.override_public_room_federation:
+                if (
+                    is_room_federate_capable(context)
+                    and self.config.override_public_room_federation
+                ):
                     raise SynapseError(
                         400,
                         "Room cannot be federated",
                         "M_INVALID_ROOM_STATE",
                     )
 
-        # Forbid "m.room.history_visibility" from being "world_readable" when configured
-        # via `prohibit_world_readable_rooms`, or always for EPA servers on TIM >= 1.2.
+        # Forbid "m.room.history_visibility" of "world_readable" when the room is capable of federation,
+        # configured via `prohibit_world_readable_rooms`, or always for EPA servers on TIM >= 1.2.
         elif (
-            (
-                self.config.prohibit_world_readable_rooms
+            event.type == EventTypes.RoomHistoryVisibility
+            and event.content["history_visibility"] == HistoryVisibility.WORLD_READABLE
+            and (
+                (
+                    self.config.prohibit_world_readable_rooms
+                    or is_room_federate_capable(context)
+                )
                 or (
                     self.config.tim_type == TimType.EPA
                     and self.config.tim_version >= TimVersion.V1_2
                 )
             )
-            and event.type == EventTypes.RoomHistoryVisibility
-            and event.content["history_visibility"] == HistoryVisibility.WORLD_READABLE
         ):
             raise SynapseError(
                 400,
@@ -959,8 +958,8 @@ class InviteChecker:
         """
         # visibility can be either "public" or "private". If not included, it defaults to "private"
         room_visibility: str = request_content.get("visibility", "private")
-        # preset can be any of "private_chat", "trusted_private_chat" or "public_chat"
-        # Do not allow "public_chat". Default is based on setting of visibility
+        # preset can be any of "private_chat", "trusted_private_chat" or "public_chat".
+        # Default is based on setting of visibility
         room_preset: str = request_content.get(
             "preset",
             (
@@ -974,11 +973,12 @@ class InviteChecker:
             room_preset == RoomCreationPreset.PUBLIC_CHAT or room_visibility == "public"
         )
 
-        if self.config.tim_type == TimType.PRO:
-            creation_content = request_content.get("creation_content", {})
-            # m.federate defaults to True if unspecified
-            can_federate = creation_content.get("m.federate", True)
+        # This will be needed in a couple places
+        creation_content = request_content.get("creation_content", {})
+        # m.federate defaults to True if unspecified
+        can_federate = creation_content.get("m.federate", True)
 
+        if self.config.tim_type == TimType.PRO:
             if can_federate and is_public:
                 if self.config.override_public_room_federation:
                     logger.debug("Overriding `m.room.create` to disable federation")
@@ -1002,14 +1002,14 @@ class InviteChecker:
         # Users can still override this by providing their own history_visibility in initial_state
         initial_state: list[dict[str, Any]] = request_content.get("initial_state", [])
 
-        # Check if history_visibility is already set in initial_state
-        has_history_visibility = any(
-            event.get("type") == EventTypes.RoomHistoryVisibility
-            for event in initial_state
-        )
+        # Save the data of the history visibility event, if it is found
+        history_visibility_event: dict[str, Any] | None = None
+        for initial_state_event in initial_state:
+            if initial_state_event.get("type") == EventTypes.RoomHistoryVisibility:
+                history_visibility_event = initial_state_event
 
         # If not set, add default history_visibility as "invited"
-        if not has_history_visibility:
+        if not history_visibility_event:
             initial_state.append(
                 {
                     "type": EventTypes.RoomHistoryVisibility,
@@ -1018,6 +1018,27 @@ class InviteChecker:
                 }
             )
             request_content["initial_state"] = initial_state
+
+        else:
+            # A provided history visibility event must not be set to world_readable if the ability to federate is
+            # enabled. This guard has a comparable twin in `check_event_allowed()`, but this one forbids creation of a
+            # dangling room. The other is for the instance of an attempt of changing this setting after the room is
+            # already created.
+            if history_visibility_event.get("content", {}).get(
+                "history_visibility"
+            ) == HistoryVisibility.WORLD_READABLE and (
+                (can_federate or self.config.prohibit_world_readable_rooms)
+                or (
+                    self.config.tim_type == TimType.EPA
+                    and self.config.tim_version >= TimVersion.V1_2
+                )
+            ):
+                raise SynapseError(
+                    400,
+                    "History visibility 'world_readable' is not allowed in a room allowed to federate, or "
+                    "world-readable rooms are forbidden on this server",
+                    "M_INVALID_ROOM_STATE",
+                )
 
         # A_28596: The TI-M specialist service MUST prevent the use of the room type
         # `de.gematik.tim.roomtype.default.v2` on room creation (TIM 1.2)
@@ -1701,3 +1722,16 @@ class InviteChecker:
                 return False
 
         return True
+
+
+def is_room_federate_capable(context: StateMap[EventBase]) -> bool:
+    # Guard that this can not be called unless the context has the creation event. That means this function should only
+    # be used in `check_event_allowed()` for any other event
+    if (EventTypes.Create, "") not in context:
+        # unfortunately, we can not know the room ID at this point
+        raise SynapseError(500, "Creation Event not found")
+
+    # Do the above so this is not an uninformative KeyError
+    creation_event = context[(EventTypes.Create, "")]
+    # `m.federate` defaults to True if unspecified
+    return creation_event.content.get(EventContentFields.FEDERATE, True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -335,20 +335,20 @@ class ConfigParsingTestCase(TestCase):
         with pytest.raises(ConfigError):
             InviteChecker.parse_config(test_config)
 
-    def test_prohibit_world_readable_rooms_override_defaults_to_true(self) -> None:
+    def test_prohibit_world_readable_rooms_override_defaults_to_false(self) -> None:
         test_config = self.config.copy()
-        config = InviteChecker.parse_config(test_config)
-        assert (
-            config.prohibit_world_readable_rooms
-        ), "`prohibit_world_readable_rooms` should default to 'True'"
-
-    def test_prohibit_world_readable_rooms_override_can_be_disabled(self) -> None:
-        test_config = self.config.copy()
-        test_config.update({"prohibit_world_readable_rooms": False})
         config = InviteChecker.parse_config(test_config)
         assert (
             config.prohibit_world_readable_rooms is False
-        ), "`prohibit_world_readable_rooms` should be `False`'"
+        ), "`prohibit_world_readable_rooms` should default to 'False'"
+
+    def test_prohibit_world_readable_rooms_override_can_be_enabled(self) -> None:
+        test_config = self.config.copy()
+        test_config.update({"prohibit_world_readable_rooms": True})
+        config = InviteChecker.parse_config(test_config)
+        assert (
+            config.prohibit_world_readable_rooms is True
+        ), "`prohibit_world_readable_rooms` should be `True`'"
 
     def test_prohibit_world_readable_rooms_override_raises(self) -> None:
         test_config = self.config.copy()

--- a/tests/test_createrooms_local.py
+++ b/tests/test_createrooms_local.py
@@ -175,13 +175,19 @@ class LocalProModeCreateRoomTest(FederatingModuleApiTestCase):
         """
         room_id = self.create_local_room(self.pro_user_a, is_public=is_public)
         assert room_id, f"{label} room should be created"
-        # This should be BAD_REQUEST for any room
+        # Public rooms, by their nature, are not allowed to be federated. Borrow that signal instead of burrowing into
+        # state calls
+        if is_public:
+            expected_code = HTTPStatus.OK
+        else:
+            expected_code = HTTPStatus.BAD_REQUEST
+
         self.helper.send_state(
             room_id,
             EventTypes.RoomHistoryVisibility,
             {"history_visibility": HistoryVisibility.WORLD_READABLE},
             tok=self.access_token_a,
-            expect_code=HTTPStatus.BAD_REQUEST,
+            expect_code=expected_code,
         )
 
     def test_create_room_default_history_visibility_invited(self) -> None:


### PR DESCRIPTION
SYN-98

BREAKING CHANGE: The configuration option
`prohibit_world_readable_rooms` now defaults to `False`. Behavior has
been adjusted to closely match the original intent of why the default
was `True`.